### PR TITLE
Adding key id tests

### DIFF
--- a/src/scitokens/scitokens.py
+++ b/src/scitokens/scitokens.py
@@ -58,7 +58,6 @@ def decode_base64(data):
     
     return base64.urlsafe_b64decode(data)
 
-
 class MissingKeyException(Exception):
     """
     No private key is present.
@@ -265,7 +264,7 @@ class SciToken(object):
         keys_data = json.loads(response.read().decode('utf-8'))
         # Loop through each key, looking for the right key id
         public_key = ""
-        raw_key = {}
+        raw_key = None
         
         # If there is no kid in the header, then just take the first key?
         if 'kid' not in header:
@@ -280,7 +279,10 @@ class SciToken(object):
                 if key['kid'] == header['kid']:
                     raw_key = key
                     break
-                
+
+        if raw_key == None:
+            raise MissingKeyException("Unable to find key at issuer {}".format(jwks_uri))
+
         if raw_key['kty'] == "RSA":
             public_key_numbers = rsa.RSAPublicNumbers(
                 long_from_bytes(raw_key['e']),

--- a/tests/test_with_http.py
+++ b/tests/test_with_http.py
@@ -65,7 +65,7 @@ class OauthRequestHandler(BaseHTTPRequestHandler):
         if self.path == "/.well-known/openid-configuration":
             to_write = json.dumps({"jwks_uri": "http://localhost:8080/oauth2/certs"})
         elif self.path == "/oauth2/certs":
-            
+
             # Dummy Key
             dummy_key = {
                 'kid': 'dummykey',
@@ -74,14 +74,14 @@ class OauthRequestHandler(BaseHTTPRequestHandler):
                 'alg': "RS256",
                 'kty': "RSA"
             }
-            
+
             key_info = {}
             key_info['kid'] = TEST_ID
             key_info['n'] = bytes_from_long(TEST_N)
             key_info['e'] = bytes_from_long(TEST_E)
             key_info['kty'] = "RSA"
             key_info['alg'] = "RS256"
-            
+
             to_write = json.dumps({'keys': [dummy_key, key_info]})
         self.wfile.write(to_write.encode())
 

--- a/tests/test_with_http.py
+++ b/tests/test_with_http.py
@@ -131,12 +131,12 @@ class TestDeserialization(unittest.TestCase):
         scitoken = scitokens.SciToken.deserialize(serialized_token, insecure=True)
 
         self.assertIsInstance(scitoken, scitokens.SciToken)
-        
+
         token = scitokens.SciToken(key=private_key, key_id="doesnotexist")
         serialized_token = token.serialize(issuer="http://localhost:8080/")
         with self.assertRaises(scitokens.scitokens.MissingKeyException):
             scitoken = scitokens.SciToken.deserialize(serialized_token, insecure=True)
-        
+
 
 
 

--- a/tests/test_with_http.py
+++ b/tests/test_with_http.py
@@ -15,6 +15,7 @@ if os.path.exists("../src"):
     sys.path.append("../src")
 
 import scitokens
+import scitokens.scitokens
 
 import cryptography.utils
 from cryptography.hazmat.primitives.asymmetric.rsa import generate_private_key
@@ -30,6 +31,7 @@ import json
 #test_kid = ""
 TEST_N = 0
 TEST_E = 0
+TEST_ID = ""
 
 def bytes_from_long(data):
     """
@@ -63,13 +65,24 @@ class OauthRequestHandler(BaseHTTPRequestHandler):
         if self.path == "/.well-known/openid-configuration":
             to_write = json.dumps({"jwks_uri": "http://localhost:8080/oauth2/certs"})
         elif self.path == "/oauth2/certs":
+            
+            # Dummy Key
+            dummy_key = {
+                'kid': 'dummykey',
+                'n': 'reallylongn',
+                'e': 'AQAB',
+                'alg': "RS256",
+                'kty': "RSA"
+            }
+            
             key_info = {}
-            #key_info['kid'] = test_kid
+            key_info['kid'] = TEST_ID
             key_info['n'] = bytes_from_long(TEST_N)
             key_info['e'] = bytes_from_long(TEST_E)
             key_info['kty'] = "RSA"
             key_info['alg'] = "RS256"
-            to_write = json.dumps({'keys': [key_info]})
+            
+            to_write = json.dumps({'keys': [dummy_key, key_info]})
         self.wfile.write(to_write.encode())
 
 
@@ -82,12 +95,13 @@ class TestDeserialization(unittest.TestCase):
     def setUp(self):
         # Start a web server to act as the "issuer"
         server_address = ('', 8080)
-        httpd = HTTPServer(server_address, OauthRequestHandler)
-        self.thread = threading.Thread(target=httpd.serve_forever)
+        self.httpd = HTTPServer(server_address, OauthRequestHandler)
+        self.thread = threading.Thread(target=self.httpd.serve_forever)
         self.thread.daemon = True
         self.thread.start()
 
     def tearDown(self):
+        del self.httpd
         del self.thread
 
     def test_deserialization(self):
@@ -96,13 +110,15 @@ class TestDeserialization(unittest.TestCase):
         """
         global TEST_N
         global TEST_E
+        global TEST_ID
         private_key = generate_private_key(
             public_exponent=65537,
             key_size=2048,
             backend=default_backend()
         )
+        TEST_ID = "stuffblah"
 
-        token = scitokens.SciToken(key=private_key)
+        token = scitokens.SciToken(key=private_key, key_id=TEST_ID)
         token.update_claims({"test": "true"})
         serialized_token = token.serialize(issuer="http://localhost:8080/")
 
@@ -115,6 +131,12 @@ class TestDeserialization(unittest.TestCase):
         scitoken = scitokens.SciToken.deserialize(serialized_token, insecure=True)
 
         self.assertIsInstance(scitoken, scitokens.SciToken)
+        
+        token = scitokens.SciToken(key=private_key, key_id="doesnotexist")
+        serialized_token = token.serialize(issuer="http://localhost:8080/")
+        with self.assertRaises(scitokens.scitokens.MissingKeyException):
+            scitoken = scitokens.SciToken.deserialize(serialized_token, insecure=True)
+        
 
 
 


### PR DESCRIPTION
Adding test when:
- Key id is not the first or only in the certs file
- When the key id does not exist in the certs file