### PR TITLE
Implement ACL generation in the Enforcer object.

### DIFF
--- a/src/scitokens/scitokens.py
+++ b/src/scitokens/scitokens.py
@@ -402,6 +402,11 @@ class Enforcer(object):
             raise EnforcementError("Issuer must be specified.")
         self._audience = audience
         self._site = site
+        self._test_authz = None
+        self._test_path = None
+        self._token_paths = set()
+        self._token_authzs = set()
+        self._now = 0
         self._validator = Validator()
         self._validator.add_validator("exp", self._validate_exp)
         self._validator.add_validator("nbf", self._validate_nbf)

--- a/tests/test_create_scitoken.py
+++ b/tests/test_create_scitoken.py
@@ -132,12 +132,11 @@ class TestCreation(unittest.TestCase):
         """
         End-to-end test of SciToken creation, verification, and validation.
         """
-        self._token['authz'] = 'write'
-        self._token['path'] = '/home/example'
+        self._token['scp'] = 'write:/home/example'
         serialized_token = self._token.serialize(issuer="local")
         token = scitokens.SciToken.deserialize(serialized_token)
         enf = scitokens.Enforcer(issuer="local")
-        self.assertTrue(enf.test(token, "write", "/home/example/test_file"))
+        self.assertTrue(enf.test(token, "write", "/home/example/test_file"), msg=enf.last_failure)
         self.assertFalse(enf.test(token, "read", "/home/example/test_file"))
         self.assertFalse(enf.test(token, "write", "/home/other/test_file"))
 

--- a/tests/test_scitokens.py
+++ b/tests/test_scitokens.py
@@ -61,7 +61,7 @@ class TestEnforcer(unittest.TestCase):
                 return True
 
         with self.assertRaises(scitokens.scitokens.EnforcementError):
-            print scitokens.Enforcer(None)
+            print(scitokens.Enforcer(None))
 
         enf = scitokens.Enforcer(self._test_issuer)
         enf.add_validator("foo", always_accept)
@@ -106,7 +106,7 @@ class TestEnforcer(unittest.TestCase):
         """
         self.assertEqual(self._token['foo'], 'bar')
         with self.assertRaises(KeyError):
-            print self._token['bar']
+            print(self._token['bar'])
         self.assertEqual(self._token.get('baz'), None)
         self.assertEqual(self._token.get('foo', 'baz'), 'bar')
         self.assertEqual(self._token.get('foo', 'baz', verified_only=True), 'baz')
@@ -134,7 +134,7 @@ class TestEnforcer(unittest.TestCase):
         self._token['path'] = '/'
         acls = enf.generate_acls(self._token)
         self.assertTrue(len(acls), 1)
-        self.assertEquals(acls[0], ('read', '/'))
+        self.assertEqual(acls[0], ('read', '/'))
 
         self._token['authz'] = ['read', 'write']
         acls = enf.generate_acls(self._token)
@@ -152,13 +152,13 @@ class TestEnforcer(unittest.TestCase):
 
         self._token['exp'] = time.time() - 600
         with self.assertRaises(scitokens.scitokens.ClaimInvalid):
-            print enf.generate_acls(self._token)
+            print(enf.generate_acls(self._token))
         self.assertTrue(enf.last_failure)
         self._token['exp'] = time.time() + 600
 
         self._token['path'] = 'foo'
         with self.assertRaises(scitokens.scitokens.InvalidPathError):
-            print enf.generate_acls(self._token)
+            print(enf.generate_acls(self._token))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Given a token, allow the `Enforcer` object to parse it and generate a set of ACLs.

This allows downstream libraries (such as the `xrootd-scitokens`) to cache the logic in the Enforcer directly and skip the call to the `scitokens` library.