### PR TITLE
Add support for `sub` claim to the Enforcer.

### DIFF
--- a/src/scitokens/scitokens.py
+++ b/src/scitokens/scitokens.py
@@ -373,6 +373,7 @@ class Enforcer(object):
         self._validator.add_validator("aud", self._validate_aud)
         self._validator.add_validator("scp", self._validate_scp)
         self._validator.add_validator("jti", self._validate_jti)
+        self._validator.add_validator("sub", self._validate_sub)
 
     def _reset_state(self):
         """
@@ -454,6 +455,9 @@ class Enforcer(object):
         if not self._audience:
             return False
         return value == self._audience
+
+    def _validate_sub(self, value):
+        return True
 
     @classmethod
     def _validate_jti(self, value):

--- a/src/scitokens/scitokens.py
+++ b/src/scitokens/scitokens.py
@@ -456,7 +456,14 @@ class Enforcer(object):
             return False
         return value == self._audience
 
+    @classmethod
     def _validate_sub(self, value):
+        """
+        SUB, or subject, should always pass.  It's mostly used for identifying
+        a tokens origin.
+        """
+        # Fix for unused argument
+        del value
         return True
 
     @classmethod

--- a/tests/test_scitokens.py
+++ b/tests/test_scitokens.py
@@ -45,6 +45,11 @@ class TestEnforcer(unittest.TestCase):
 
     _test_issuer = "https://scitokens.org/unittest"
 
+    @staticmethod
+    def always_accept(value):
+        if value or not value:
+            return True
+
     def setUp(self):
         """
         Setup a sample token for testing the enforcer.
@@ -66,18 +71,11 @@ class TestEnforcer(unittest.TestCase):
         """
         Test the Enforcer object.
         """
-        def always_accept(value):
-            """
-            A validator function that always accepts a given value.
-            """
-            if value or not value:
-                return True
-
         with self.assertRaises(scitokens.scitokens.EnforcementError):
             print(scitokens.Enforcer(None))
 
         enf = scitokens.Enforcer(self._test_issuer)
-        enf.add_validator("foo", always_accept)
+        enf.add_validator("foo", self.always_accept)
 
         self.assertFalse(enf.test(self._token, "read", "/"), msg=enf.last_failure)
 
@@ -85,7 +83,7 @@ class TestEnforcer(unittest.TestCase):
         self.assertTrue(enf.test(self._token, "read", "/"), msg=enf.last_failure)
 
         enf = scitokens.Enforcer(self._test_issuer, audience = "https://example.unl.edu")
-        enf.add_validator("foo", always_accept)
+        enf.add_validator("foo", self.always_accept)
         self.assertTrue(enf.test(self._token, "read", "/"), msg=enf.last_failure)
 
         self._token["scp"] = "read:/foo/bar"
@@ -94,7 +92,7 @@ class TestEnforcer(unittest.TestCase):
         self._token["site"] = "T2_US_Example"
         self.assertFalse(enf.test(self._token, "read", "/foo/bar"), msg=enf.last_failure)
         enf = scitokens.Enforcer(self._test_issuer, site="T2_US_Example")
-        enf.add_validator("foo", always_accept)
+        enf.add_validator("foo", self.always_accept)
         self.assertTrue(enf.test(self._token, "read", "/foo/bar"), msg=enf.last_failure)
 
         self.assertFalse(enf.test(self._token, "write", "/foo/bar"), msg=enf.last_failure)
@@ -139,12 +137,8 @@ class TestEnforcer(unittest.TestCase):
         """
         Test the generation of ACLs
         """
-        def always_accept(value):
-            if value or not value:
-                return True
-
         enf = scitokens.Enforcer(self._test_issuer)
-        enf.add_validator("foo", always_accept)
+        enf.add_validator("foo", self.always_accept)
 
         self._token['scp'] = 'read:/'
         acls = enf.generate_acls(self._token)
@@ -178,6 +172,18 @@ class TestEnforcer(unittest.TestCase):
         self._token['scp'] = 'read'
         with self.assertRaises(scitokens.scitokens.InvalidAuthorizationResource):
             print(enf.generate_acls(self._token))
+
+    def test_sub(self):
+        """
+        Verify that tokens with the `sub` set are accepted.
+        """
+        self._token['sub'] = 'Some Great User'
+        enf = scitokens.Enforcer(self._test_issuer)
+        enf.add_validator("foo", self.always_accept)
+
+        self._token['scp'] = 'read:/'
+        acls = enf.generate_acls(self._token)
+        self.assertTrue(len(acls), 1)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Without this, any token containing the `sub` claim would fail the Enforcer.

Includes simple unit test.