### PR TITLE
Adding next_update time

### DIFF
--- a/src/scitokens/utils/keycache.py
+++ b/src/scitokens/utils/keycache.py
@@ -132,7 +132,8 @@ class KeyCache(object):
                     conn.close()
                     return public_key
                 except:
-                    print("Unable to get key triggered by next update")
+                    logger = logging.getlogger("scitokens")
+                    logger.warning("Unable to get key triggered by next update")
                     conn.close()
                     return load_pem_public_key(row['keydata'].encode(), backend=backends.default_backend())
 

--- a/src/scitokens/utils/keycache.py
+++ b/src/scitokens/utils/keycache.py
@@ -119,7 +119,7 @@ class KeyCache(object):
         conn.row_factory = sqlite3.Row
         curs = conn.cursor()
         curs.execute(key_query.format(issuer=issuer, key_id=key_id))
-        
+
         row = curs.fetchone()
         if row != None:
             # If it's time to update the key, but the key is still valid
@@ -135,12 +135,12 @@ class KeyCache(object):
                     print "Unable to get key triggered by next update"
                     conn.close()
                     return load_pem_public_key(row['keydata'].encode(), backend=backends.default_backend())
-            
+
             # If it's not time to update the key, but the key is still valid
             elif self._check_validity(row):
                 conn.close()
                 return load_pem_public_key(row['keydata'].encode(), backend=backends.default_backend())
-                
+
             # If it's not time to update the key, and the key is not valid
             else:
 

--- a/src/scitokens/utils/keycache.py
+++ b/src/scitokens/utils/keycache.py
@@ -132,7 +132,7 @@ class KeyCache(object):
                     conn.close()
                     return public_key
                 except:
-                    print "Unable to get key triggered by next update"
+                    print("Unable to get key triggered by next update")
                     conn.close()
                     return load_pem_public_key(row['keydata'].encode(), backend=backends.default_backend())
 

--- a/src/scitokens/utils/keycache.py
+++ b/src/scitokens/utils/keycache.py
@@ -94,7 +94,8 @@ class KeyCache(object):
         Given an open database cursor to a key cache, insert a key.
         """
         # Add the key to the cache
-        insert_key_statement = "INSERT INTO keycache VALUES('{issuer}', '{expiration}', '{key_id}', '{keydata}', '{next_update}')"
+        insert_key_statement = "INSERT INTO keycache VALUES('{issuer}', '{expiration}', '{key_id}', \
+                               '{keydata}', '{next_update}')"
         keydata = public_key.public_bytes(Encoding.PEM, PublicFormat.PKCS1).decode('ascii')
 
         curs.execute(insert_key_statement.format(issuer=issuer, expiration=time.time()+cache_timer, key_id=key_id,
@@ -141,9 +142,9 @@ class KeyCache(object):
                     conn.commit()
                     conn.close()
                     return public_key
-                except:
+                except Exception as ex:
                     logger = logging.getLogger("scitokens")
-                    logger.warning("Unable to get key triggered by next update")
+                    logger.warning("Unable to get key triggered by next update: {0}".format(str(ex)))
                     return load_pem_public_key(row['keydata'].encode(), backend=backends.default_backend())
 
             # If it's not time to update the key, but the key is still valid

--- a/src/scitokens/utils/keycache.py
+++ b/src/scitokens/utils/keycache.py
@@ -144,7 +144,6 @@ class KeyCache(object):
                 except:
                     logger = logging.getLogger("scitokens")
                     logger.warning("Unable to get key triggered by next update")
-                    conn.close()
                     return load_pem_public_key(row['keydata'].encode(), backend=backends.default_backend())
 
             # If it's not time to update the key, but the key is still valid

--- a/src/scitokens/utils/keycache.py
+++ b/src/scitokens/utils/keycache.py
@@ -127,7 +127,16 @@ class KeyCache(object):
             if int(row['next_update']) < time.time() and self._check_validity(row):
                 # Try to update the key, but if it doesn't work, just return the saved one
                 try:
+                    # Close the sqllite lock
+                    conn.commit()
+                    conn.close()
+
+                    # Get the public key, probably from a webserver
                     public_key, cache_timer = self._get_issuer_publickey(issuer, key_id, insecure)
+
+                    # Get the sqllite connection again
+                    conn = sqlite3.connect(self.cache_location)
+                    curs = conn.cursor()
                     self._addkeyinfo(curs, issuer, key_id, public_key, cache_timer)
                     conn.commit()
                     conn.close()
@@ -152,10 +161,17 @@ class KeyCache(object):
                 curs.execute("DELETE FROM keycache WHERE issuer = '{}' AND key_id = '{}'".format(row['issuer'],
                              row['key_id']))
 
+        # Close the sqllite lock
+        conn.commit()
+        conn.close()
+
         # If it reaches here, then no key was found in the SQL
         # Try checking the issuer (negative cache?)
         public_key, cache_timer = self._get_issuer_publickey(issuer, key_id, insecure)
 
+        # Get the sqllite connection again
+        conn = sqlite3.connect(self.cache_location)
+        curs = conn.cursor()
         self._addkeyinfo(curs, issuer, key_id, public_key, cache_timer)
 
         # Save (commit) the changes

--- a/src/scitokens/utils/keycache.py
+++ b/src/scitokens/utils/keycache.py
@@ -61,7 +61,7 @@ class KeyCache(object):
             KEYCACHE_INSTANCE = KeyCache()
         return KEYCACHE_INSTANCE
 
-    def addkeyinfo(self, issuer, key_id, public_key, cache_timer=0):
+    def addkeyinfo(self, issuer, key_id, public_key, cache_timer=0, next_update=0):
         """
         Add a single, known public key to the cache.
         
@@ -69,26 +69,32 @@ class KeyCache(object):
         :param str key_id: Key Identifier
         :param public_key: Cryptography public_key object
         :param int cache_timer: Cache lifetime of the public_key
+        :param int next_update: Unix epoch timestamp for when the next update should occur
         """
+        
+        # If the next_update is 0, then set it to 1 hour
+        if next_update == 0:
+            next_update = time.time() + 3600
+        
         conn = sqlite3.connect(self.cache_location)
         conn.row_factory = sqlite3.Row
         curs = conn.cursor()
         curs.execute("DELETE FROM keycache WHERE issuer = '{}' AND key_id = '{}'".format(issuer, key_id))
-        KeyCache._addkeyinfo(curs, issuer, key_id, public_key, cache_timer=cache_timer)
+        KeyCache._addkeyinfo(curs, issuer, key_id, public_key, cache_timer=cache_timer, next_update = next_update)
         conn.commit()
         conn.close()
 
     @staticmethod
-    def _addkeyinfo(curs, issuer, key_id, public_key, cache_timer=0):
+    def _addkeyinfo(curs, issuer, key_id, public_key, cache_timer=0, next_update = 0):
         """
         Given an open database cursor to a key cache, insert a key.
         """
         # Add the key to the cache
-        insert_key_statement = "INSERT INTO keycache VALUES('{issuer}', '{expiration}', '{key_id}', '{keydata}')"
+        insert_key_statement = "INSERT INTO keycache VALUES('{issuer}', '{expiration}', '{key_id}', '{keydata}', '{next_update}')"
         keydata = public_key.public_bytes(Encoding.PEM, PublicFormat.PKCS1).decode('ascii')
 
         curs.execute(insert_key_statement.format(issuer=issuer, expiration=time.time()+cache_timer, key_id=key_id,
-                                                 keydata=keydata))
+                                                 keydata=keydata, next_update=next_update))
         if curs.rowcount != 1:
             raise UnableToWriteKeyCache("Unable to insert into key cache")
 
@@ -112,12 +118,31 @@ class KeyCache(object):
         
         row = curs.fetchone()
         if row != None:
-            if self._check_validity(row):
-                # Convert the PEM formatted public key to a public key object
+            # If it's time to update the key, but the key is still valid
+            if int(row['next_update']) < time.time() and self._check_validity(row):
+                # Try to update the key, but if it doesn't work, just return the saved one
+                try:
+                    public_key, cache_timer = self._get_issuer_publickey(issuer, key_id, insecure)
+                    self._addkeyinfo(curs, issuer, key_id, public_key, cache_timer)
+                    conn.commit()
+                    conn.close()
+                    return public_key
+                except:
+                    print "Unable to get key triggered by next update"
+                    conn.close()
+                    return load_pem_public_key(row['keydata'].encode(), backend=backends.default_backend())
+            
+            # If it's not time to update the key, but the key is still valid
+            elif self._check_validity(row):
                 conn.close()
                 return load_pem_public_key(row['keydata'].encode(), backend=backends.default_backend())
+                
+            # If it's not time to update the key, and the key is not valid
             else:
+
                 # Delete the row
+                # If it gets to this point, then there is a row for the key, but it's:
+                # - Not valid anymore
                 curs.execute("DELETE FROM keycache WHERE issuer = '{}' AND key_id = '{}'".format(row['issuer'],
                              row['key_id']))
 
@@ -281,6 +306,7 @@ class KeyCache(object):
                       "expiration integer NOT NULL,"
                       "key_id text,"
                       "keydata text NOT NULL,"
+                      "next_update integer NOT NULL,"
                       "PRIMARY KEY (issuer, key_id))")
         # Save (commit) the changes
         conn.commit()

--- a/tests/test_keycache.py
+++ b/tests/test_keycache.py
@@ -167,7 +167,7 @@ class TestKeyCache(unittest.TestCase):
             format=serialization.PublicFormat.SubjectPublicKeyInfo
         )
 
-        self.keycache.addkeyinfo("https://doesnotexists.com/", "blahstuff", public_key, cache_timer=60, next_update=time.time()-1)
+        self.keycache.addkeyinfo("https://doesnotexists.com/", "blahstuff", public_key, cache_timer=60, next_update=-1)
 
         # Even though the cache is still valid, the next update is triggered
         # We should still get the key, even though the next update fails 
@@ -210,7 +210,7 @@ class TestKeyCache(unittest.TestCase):
         )
         
         # Now try to get the public key from the server
-        self.keycache.addkeyinfo("http://localhost:{}/".format(server_address[1]), test_id, public_key, cache_timer=60, next_update=time.time()-1)
+        self.keycache.addkeyinfo("http://localhost:{}/".format(server_address[1]), test_id, public_key, cache_timer=60, next_update=-1)
 
         # Next update should trigger now
         pubkey_from_keycache = self.keycache.getkeyinfo("http://localhost:{}/".format(server_address[1]),

--- a/tests/test_keycache.py
+++ b/tests/test_keycache.py
@@ -6,6 +6,7 @@ import os
 import tempfile
 import shutil
 import unittest
+import time
 from scitokens.utils.keycache import KeyCache
 from scitokens.utils.errors import UnableToCreateCache
 from cryptography.hazmat.primitives.asymmetric.rsa import generate_private_key
@@ -149,3 +150,87 @@ class TestKeyCache(unittest.TestCase):
 
         self.assertEqual(cache_timer, 3600)
         create_webserver.shutdown_server()
+        
+    def test_cache_update_time(self):
+        """
+        Test if the cache next_update works
+        """
+        # Create a pem encoded public key
+        private_key = generate_private_key(
+            public_exponent=65537,
+            key_size=2048,
+            backend=default_backend()
+        )
+        public_key = private_key.public_key()
+        public_pem = public_key.public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo
+        )
+
+        self.keycache.addkeyinfo("https://doesnotexists.com/", "blahstuff", public_key, cache_timer=60, next_update=time.time()-1)
+
+        # Even though the cache is still valid, the next update is triggered
+        # We should still get the key, even though the next update fails 
+        # (invalid url)
+        pubkey = self.keycache.getkeyinfo("https://doesnotexists.com/", "blahstuff")
+
+        public_pem2 = pubkey.public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo
+        )
+
+        self.assertEqual(public_pem, public_pem2)
+
+    def test_cache_update_trigger(self):
+        """
+        Test when the next_update triggers and goes to the webserver
+        """
+        # Stand up an HTTP server
+        private_key = generate_private_key(
+            public_exponent=65537,
+            key_size=2048,
+            backend=default_backend()
+        )
+        public_numbers = private_key.public_key().public_numbers()
+        test_id = "thisisatestid"
+        server_address = create_webserver.start_server(public_numbers.n, public_numbers.e, test_id)
+        print(server_address)
+
+        # Create a pem encoded public key, just to insert, want to make sure
+        # it downloads from the server
+        private_key = generate_private_key(
+            public_exponent=65537,
+            key_size=2048,
+            backend=default_backend()
+        )
+        public_key = private_key.public_key()
+        public_pem = public_key.public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo
+        )
+        
+        # Now try to get the public key from the server
+        self.keycache.addkeyinfo("http://localhost:{}/".format(server_address[1]), test_id, public_key, cache_timer=60, next_update=time.time()-1)
+
+        # Next update should trigger now
+        pubkey_from_keycache = self.keycache.getkeyinfo("http://localhost:{}/".format(server_address[1]),
+                                 test_id,
+                                 insecure=True)
+
+        # Now compare the 2 public keys
+        public_pem = private_key.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo
+        )
+
+        pubkey_pem_from_keycache = pubkey_from_keycache.public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo
+        )
+
+        self.assertEqual(public_pem, pubkey_pem_from_keycache)
+
+        create_webserver.shutdown_server()
+        
+        
+        

--- a/tests/test_keycache.py
+++ b/tests/test_keycache.py
@@ -6,7 +6,6 @@ import os
 import tempfile
 import shutil
 import unittest
-import time
 from scitokens.utils.keycache import KeyCache
 from scitokens.utils.errors import UnableToCreateCache
 from cryptography.hazmat.primitives.asymmetric.rsa import generate_private_key
@@ -150,7 +149,7 @@ class TestKeyCache(unittest.TestCase):
 
         self.assertEqual(cache_timer, 3600)
         create_webserver.shutdown_server()
-        
+
     def test_cache_update_time(self):
         """
         Test if the cache next_update works
@@ -170,7 +169,7 @@ class TestKeyCache(unittest.TestCase):
         self.keycache.addkeyinfo("https://doesnotexists.com/", "blahstuff", public_key, cache_timer=60, next_update=-1)
 
         # Even though the cache is still valid, the next update is triggered
-        # We should still get the key, even though the next update fails 
+        # We should still get the key, even though the next update fails
         # (invalid url)
         pubkey = self.keycache.getkeyinfo("https://doesnotexists.com/", "blahstuff")
 
@@ -208,9 +207,13 @@ class TestKeyCache(unittest.TestCase):
             encoding=serialization.Encoding.PEM,
             format=serialization.PublicFormat.SubjectPublicKeyInfo
         )
-        
+
         # Now try to get the public key from the server
-        self.keycache.addkeyinfo("http://localhost:{}/".format(server_address[1]), test_id, public_key, cache_timer=60, next_update=-1)
+        self.keycache.addkeyinfo("http://localhost:{}/".format(server_address[1]),
+                                 test_id,
+                                 public_key,
+                                 cache_timer=60,
+                                 next_update=-1)
 
         # Next update should trigger now
         pubkey_from_keycache = self.keycache.getkeyinfo("http://localhost:{}/".format(server_address[1]),
@@ -231,6 +234,4 @@ class TestKeyCache(unittest.TestCase):
         self.assertEqual(public_pem, pubkey_pem_from_keycache)
 
         create_webserver.shutdown_server()
-        
-        
-        
+


### PR DESCRIPTION
Adding next update time.  A timer when the cache will attempt to update the key, but if it fails, it's non-fatal.