### PR TITLE
Adding ver (version) and opt (optional)

### DIFF
--- a/src/scitokens/scitokens.py
+++ b/src/scitokens/scitokens.py
@@ -363,6 +363,9 @@ class Enforcer(object):
 
     _authz_requiring_path = set(["read", "write"])
 
+    # An array of versions of scitokens that we understand and can enforce
+    _versions_understood = [ 1 ]
+
     def __init__(self, issuer, site=None, audience=None):
         self._issuer = issuer
         self.last_failure = None
@@ -385,6 +388,8 @@ class Enforcer(object):
         self._validator.add_validator("scp", self._validate_scp)
         self._validator.add_validator("jti", self._validate_jti)
         self._validator.add_validator("sub", self._validate_sub)
+        self._validator.add_validator("ver", self._validate_ver)
+        self._validator.add_validator("opt", self._validate_opt)
 
     def _reset_state(self):
         """
@@ -466,6 +471,19 @@ class Enforcer(object):
         if not self._audience:
             return False
         return value == self._audience
+
+    def _validate_ver(self, value):
+        if value in self._versions_understood:
+            return True
+        else:
+            return False
+
+    def _validate_opt(self, value):
+        """
+        Opt is optional information.  We don't know what's in there, so just
+        return true.
+        """
+        return True
 
     @classmethod
     def _validate_sub(self, value):

--- a/src/scitokens/scitokens.py
+++ b/src/scitokens/scitokens.py
@@ -478,11 +478,13 @@ class Enforcer(object):
         else:
             return False
 
+    @classmethod
     def _validate_opt(self, value):
         """
         Opt is optional information.  We don't know what's in there, so just
         return true.
         """
+        del value
         return True
 
     @classmethod

--- a/tests/test_create_scitoken.py
+++ b/tests/test_create_scitoken.py
@@ -152,8 +152,8 @@ class TestCreation(unittest.TestCase):
         # Now set it to a number it shouldn't understand
         self._token['ver'] = 9999
         self.assertFalse(enf.test(self._token, "write", "/home/example/test_file"))
-        
-    def test_ver(self):
+
+    def test_opt(self):
         """
         Testing the version attribute
         """

--- a/tests/test_create_scitoken.py
+++ b/tests/test_create_scitoken.py
@@ -140,5 +140,27 @@ class TestCreation(unittest.TestCase):
         self.assertFalse(enf.test(token, "read", "/home/example/test_file"))
         self.assertFalse(enf.test(token, "write", "/home/other/test_file"))
 
+    def test_ver(self):
+        """
+        Testing the version attribute
+        """
+        self._token['ver'] = 1
+        self._token['scp'] = "write:/home/example"
+        enf = scitokens.Enforcer(issuer="local")
+        self.assertTrue(enf.test(self._token, "write", "/home/example/test_file"))
+
+        # Now set it to a number it shouldn't understand
+        self._token['ver'] = 9999
+        self.assertFalse(enf.test(self._token, "write", "/home/example/test_file"))
+        
+    def test_ver(self):
+        """
+        Testing the version attribute
+        """
+        self._token['opt'] = "This is optional information, and should always return true"
+        self._token['scp'] = "write:/home/example"
+        enf = scitokens.Enforcer(issuer="local")
+        self.assertTrue(enf.test(self._token, "write", "/home/example/test_file"))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The ver (version) attribute enforces versions of scitokens
that it understands.

The opt (optional) attribute adds optional arguments that
the scitoken can contain.