### PR TITLE
Add contains

### DIFF
--- a/src/scitokens/scitokens.py
+++ b/src/scitokens/scitokens.py
@@ -155,6 +155,19 @@ class SciToken(object):
         if claim in self._verified_claims:
             return self._verified_claims[claim]
         raise KeyError(claim)
+        
+    def __contains__(self, claim):
+        """
+        Access the value corresponding to a particular claim; will
+        return claims from both the verified and unverified claims.
+
+        If a claim is not present, then a KeyError is thrown.
+        """
+        if claim in self._claims:
+            return True
+        if claim in self._verified_claims:
+            return True
+        return False
 
     def get(self, claim, default=None, verified_only=False):
         """

--- a/tests/test_create_scitoken.py
+++ b/tests/test_create_scitoken.py
@@ -162,14 +162,14 @@ class TestCreation(unittest.TestCase):
         self._token['scp'] = "write:/home/example"
         enf = scitokens.Enforcer(issuer="local")
         self.assertTrue(enf.test(self._token, "write", "/home/example/test_file"))
-        
+
     def test_contains(self):
         """
         Testing the contains attribute
         """
         self._token['opt'] = "This is optional information, and should always return true"
         self._token['scp'] = "write:/home/example"
-        
+
         self.assertTrue('opt' in self._token)
         self.assertTrue('scp' in self._token)
         self.assertFalse('notin' in self._token)

--- a/tests/test_create_scitoken.py
+++ b/tests/test_create_scitoken.py
@@ -162,6 +162,17 @@ class TestCreation(unittest.TestCase):
         self._token['scp'] = "write:/home/example"
         enf = scitokens.Enforcer(issuer="local")
         self.assertTrue(enf.test(self._token, "write", "/home/example/test_file"))
+        
+    def test_contains(self):
+        """
+        Testing the contains attribute
+        """
+        self._token['opt'] = "This is optional information, and should always return true"
+        self._token['scp'] = "write:/home/example"
+        
+        self.assertTrue('opt' in self._token)
+        self.assertTrue('scp' in self._token)
+        self.assertFalse('notin' in self._token)
 
     def test_no_kid(self):
         """


### PR DESCRIPTION
Adding `__contains__` so that we can perform actions like:

    if 'scp' in token:
        # Perform action