### PR TITLE
Include license in distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE README.rst

--- a/configs/python-scitokens.spec
+++ b/configs/python-scitokens.spec
@@ -86,6 +86,7 @@ touch %{buildroot}%{_bindir}/scitokens-admin-create-token
 
 %if 0%{?rhel} >= 8
 %files -n python3-%{pypi_name}
+%license LICENSE
 %{python3_sitelib}/%{pypi_name}
 %{python3_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
 %doc README.rst
@@ -94,6 +95,7 @@ touch %{buildroot}%{_bindir}/scitokens-admin-create-token
 %else
 
 %files -n python3-%{pypi_name}
+%license LICENSE
 %{python3_sitelib}/%{pypi_name}
 %{python3_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
 %doc README.rst
@@ -103,6 +105,7 @@ touch %{buildroot}%{_bindir}/scitokens-admin-create-token
 %{_bindir}/scitokens-admin-create-token3
 
 %files -n python2-%{pypi_name}
+%license LICENSE
 %{python2_sitelib}/%{pypi_name}
 %{python2_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
 %doc README.rst

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+license_files = LICENSE


### PR DESCRIPTION
This PR adds new files to include the `LICENSE` file in distributions

- new MANIFEST.in for `setup.py sdist` tarballs
- new setup.cfg for `setup.py bdist_wheel` wheels

And modifies the spec file to include it in binary rpms.