### PR TITLE
Fix dependencies

### DIFF
--- a/src/scitokens/scitokens.py
+++ b/src/scitokens/scitokens.py
@@ -114,7 +114,7 @@ class SciToken(object):
         raise NotImplementedError()
 
 
-    def serialize(self, include_key=False, issuer=None, lifetime=600) -> bytes:
+    def serialize(self, include_key=False, issuer=None, lifetime=600):
         """
         Serialize the existing SciToken.
         

--- a/src/scitokens/scitokens.py
+++ b/src/scitokens/scitokens.py
@@ -114,7 +114,7 @@ class SciToken(object):
         raise NotImplementedError()
 
 
-    def serialize(self, include_key=False, issuer=None, lifetime=600):
+    def serialize(self, include_key=False, issuer=None, lifetime=600) -> bytes:
         """
         Serialize the existing SciToken.
         
@@ -171,8 +171,10 @@ class SciToken(object):
         
         global LOGGER
         LOGGER.info("Signed Token: {0}".format(str(payload)))
-        
-        return encoded
+
+        # Encode the returned string for backwards compatibility.
+        # Previous versions of PyJWT returned bytes
+        return str.encode(encoded)
 
     def update_claims(self, claims):
         """

--- a/src/scitokens/scitokens.py
+++ b/src/scitokens/scitokens.py
@@ -281,7 +281,8 @@ class SciToken(object):
         serialized_jwt = info[0] + "." + info[1] + "." + info[2]
 
         unverified_headers = jwt.get_unverified_header(serialized_jwt)
-        unverified_payload = jwt.decode(serialized_jwt, verify=False, algorithms=['RS256', 'ES256'])
+        unverified_payload = jwt.decode(serialized_jwt, verify=False, algorithms=['RS256', 'ES256'],
+                                        options={"verify_signature": False})
         
         # Get the public key from the issuer
         keycache = KeyCache.KeyCache().getinstance()


### PR DESCRIPTION
Update of PyJWT dependency broke some behavior.

- New method to read unverified payload
- PyJWT serialize returns a string now, rather than bytes.=