### PR TITLE
Add base SciTokensException class

### DIFF
--- a/src/scitokens/utils/errors.py
+++ b/src/scitokens/utils/errors.py
@@ -2,7 +2,14 @@
 Error and Exceptions in the SciTokens library
 """
 
-class MissingKeyException(Exception):
+
+class SciTokensException(Exception):
+    """
+    Base class for exceptions in the SciTokens library
+    """
+    pass
+
+class MissingKeyException(SciTokensException):
     """
     No private key is present.
 
@@ -11,7 +18,7 @@ class MissingKeyException(Exception):
     """
     pass
 
-class UnsupportedKeyException(Exception):
+class UnsupportedKeyException(SciTokensException):
     """
     Key is present but is of an unsupported format.
 
@@ -20,26 +27,26 @@ class UnsupportedKeyException(Exception):
     """
     pass
 
-class MissingIssuerException(Exception):
+class MissingIssuerException(SciTokensException):
     """
     Missing the issuer in the SciToken, unable to verify token
     """
     pass
 
-class NonHTTPSIssuer(Exception):
+class NonHTTPSIssuer(SciTokensException):
     """
     Non HTTPs issuer, as required by draft-ietf-oauth-discovery-07
     https://tools.ietf.org/html/draft-ietf-oauth-discovery-07
     """
     pass
 
-class InvalidTokenFormat(Exception):
+class InvalidTokenFormat(SciTokensException):
     """
     Encoded token has an invalid format.
     """
     pass
 
-class UnableToCreateCache(Exception):
+class UnableToCreateCache(SciTokensException):
     """
     Unable to make the KeyCache
     """

--- a/src/scitokens/utils/keycache.py
+++ b/src/scitokens/utils/keycache.py
@@ -32,7 +32,7 @@ from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat,
 import cryptography.hazmat.backends as backends
 import cryptography.hazmat.primitives.asymmetric.ec as ec
 import cryptography.hazmat.primitives.asymmetric.rsa as rsa
-from scitokens.utils.errors import MissingKeyException, NonHTTPSIssuer, UnableToCreateCache, UnsupportedKeyException
+from scitokens.utils.errors import SciTokensException, MissingKeyException, NonHTTPSIssuer, UnableToCreateCache, UnsupportedKeyException
 from scitokens.utils import long_from_bytes
 import scitokens.utils.config as config
 
@@ -40,7 +40,7 @@ import scitokens.utils.config as config
 CACHE_FILENAME = "scitokens_keycache.sqllite"
 KEYCACHE_INSTANCE = None
 
-class UnableToWriteKeyCache(Exception):
+class UnableToWriteKeyCache(SciTokensException):
     """
     For whatever reason, unable to write to the Key Cache
     """


### PR DESCRIPTION
This PR adds a new `SciTokensException` class as the parent for all of the existing exceptions defined in `scitokens.utils.errors`, to make it easier to catch all scitokens errors downstream (but not anything else).