### PR TITLE
Run continuous integration on macOS and windows

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        python -m pip install -r requirements.txt
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,10 +12,11 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
     strategy:
       matrix:
+        os: [macOS, Ubuntu, Windows]
         python-version: [3.7, 3.8, 3.9]
+    runs-on: ${{ matrix.os }}-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/tests/test_admin_create_key.py
+++ b/tests/test_admin_create_key.py
@@ -31,7 +31,7 @@ class TestKeyCreate(unittest.TestCase):
     to_delete = []
 
     def setUp(self):
-        os.environ['PYTHONPATH'] = ":".join(sys.path)
+        os.environ['PYTHONPATH'] = os.pathsep.join(sys.path)
         self.to_delete = []
 
     @staticmethod

--- a/tests/test_create_scitoken.py
+++ b/tests/test_create_scitoken.py
@@ -316,7 +316,10 @@ class TestCreation(unittest.TestCase):
            pass
 
         # move any /tmp/bt_u$ID file out of the way
-        bt_file = 'bt_u{}'.format(os.geteuid())
+        try:
+            bt_file = 'bt_u{}'.format(os.geteuid())
+        except AttributeError as exc:  # windows doesn't have geteuid
+            self.skipTest(str(exc))
         bt_path = os.path.join('/tmp', bt_file)
         (bt_fd, bt_tmp) = tempfile.mkstemp()
         os.close(bt_fd)


### PR DESCRIPTION
This PR updates the CI to run the `python-package` workflow on Windows and macOS, mainly to validate that the test suite passes on those platforms, and then fixes issues with the test suite on windows (at least).