### PR TITLE
Check verified claims for issuer in SciToken.serialize

### DIFF
--- a/src/scitokens/scitokens.py
+++ b/src/scitokens/scitokens.py
@@ -133,11 +133,11 @@ class SciToken(object):
             raise MissingKeyException("Unable to serialize, missing private key")
 
         # Issuer needs to be available, otherwise throw an error
-        if issuer == None and 'iss' not in self._claims:
+        if issuer is None and 'iss' not in self:
             raise MissingIssuerException("Issuer not specific in claims or as argument")
 
         if not issuer:
-            issuer = self._claims['iss']
+            issuer = self['iss']
 
         # Set the issue and expiration time of the token
         issue_time = int(time.time())


### PR DESCRIPTION
This PR patches `SciToken.serialize` to check all claims (i.e. including 'verified' claims) for the issuer, to allow repeated calls to `.serialize()` for the same token.

Without this change the following occurs:

```python
>>> from cryptography.hazmat.primitives.asymmetric.rsa import generate_private_key
>>> from scitokens import SciToken
>>> key = generate_private_key(public_exponent=65537, key_size=4096)
>>> token = SciToken(key=key)
>>> token["iss"] = "test"
>>> token.serialize()
b'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiZXhwIjoxNjI1MzE0ODQ4LCJpYXQiOjE2MjUzMTQyNDgsIm5iZiI6MTYyNTMxNDI0OCwianRpIjoiYTVhZWJhYzctOWU3OS00Y2I4LTk2MjUtNGZhM2NlZmU4NzM4In0.hn4mCt6TIrLDs1Q4eYH26MQm9xE2FinkFqK8ZLmTTNUzNHvI9ZWScdLJC5hNLyzARmymxc05rw-GRjgLgVa_i6wS4A99y6MCZA77vNYWXoneKpOhxDkq-oBuVAEyx8Ua6KKNzfWZ_mPAcBSYBN-sDSZReaO0gR5p4klG4CK5JKAarvTjRRPe3Pyt7HfYgglVsV3uQkBWqfKmg4PYmwT03fFjI1lJYzuMuTU2FzPoyODuQp58MGK8XnkupiGgjSPombfcHBL9uYOcsXPShQt8qbQuODXnhp3hjrH3iBeySpCWZJA20P0emPEwifsM-lP5X1e9UdTkN-JExytq3MSkGPUQoaEWf5J-sPppT_y94TvuIVY1sxoTq6NbycFZ0ur6X6y9aIvhaYlArwu2ybNQw3-tmgpMlOXyeMtca1EOqypxbaN65fNEGBHyvnhqTq0dl9_PTjLu17lZeGrYfipMLO23Z5LK1dI3XHTjSPsYppEFRdHRZ9g53NZCmPAD8cmQfzLWHmUTe64e9JCJX3zlX9pFnGliyVLSKuf1TTyJ3RKRRJ3iou3clWWi5ueVIz--T5bLRehJfnJNVgrVrNEop__y35JYmm_8-UeQFGzzK0WY7evCB6kPDAbAJkc0mt-HxxRgdvguu70eQeDgd-fkKA2Td7HWt6GduLspJ_zYWkE'
>>> token.serialize()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/duncan/opt/miniconda3/envs/py39/lib/python3.9/site-packages/scitokens/scitokens.py", line 137, in serialize
    raise MissingIssuerException("Issuer not specific in claims or as argument")
scitokens.utils.errors.MissingIssuerException: Issuer not specific in claims or as argument
```