### PR TITLE
Move package version declaration into 'scitokens' module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,29 @@
 Install file for SciTokens project.
 """
 
+import os.path
+import re
+
 import setuptools
 
+
+def find_version(path, varname="__version__"):
+    """Parse the version metadata variable in the given file.
+    """
+    with open(path, 'r') as fobj:
+        version_file = fobj.read()
+    version_match = re.search(
+        r"^{0} = ['\"]([^'\"]*)['\"]".format(varname),
+        version_file,
+        re.M,
+    )
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+
 setuptools.setup(name="scitokens",
-                 version="1.4.0",
+                 version=find_version(os.path.join("src", "scitokens", "__init__.py")),
                  description="SciToken reference implementation library",
                  author_email="team@scitokens.org",
                  author="Brian Bockelman",

--- a/src/scitokens/__init__.py
+++ b/src/scitokens/__init__.py
@@ -6,3 +6,4 @@ Module for creating and using SciTokens.
 from .scitokens import SciToken, Validator, Enforcer, MissingClaims
 from .utils.config import set_config
 
+__version__ = "1.4.0"


### PR DESCRIPTION
This PR moves the hardcoded package version number from `setup.py` into `src/scitokens/__init__.py` so that it gets installed at runtime as `scitokens.__version__`, allowing users to inspect the version trivially.

`setup.py` now contains a function that parses the `__version__` metadata variable back out of the module so that there's still only one place where the version is specified. This is done with text parsing, rather than by `import`ing the module, so that it can be done without any of the runtime requirements installed.