### PR TITLE
Remove verify=False keyword from calls to decode()

### DIFF
--- a/src/scitokens/scitokens.py
+++ b/src/scitokens/scitokens.py
@@ -284,7 +284,7 @@ class SciToken(object):
         serialized_jwt = info[0] + "." + info[1] + "." + info[2]
 
         unverified_headers = jwt.get_unverified_header(serialized_jwt)
-        unverified_payload = jwt.decode(serialized_jwt, verify=False, algorithms=['RS256', 'ES256'],
+        unverified_payload = jwt.decode(serialized_jwt, algorithms=['RS256', 'ES256'],
                                         options={"verify_signature": False})
         
         # Get the public key from the issuer

--- a/tests/create_sample_token.py
+++ b/tests/create_sample_token.py
@@ -80,7 +80,7 @@ def main():
     #numbers = loaded_private_key.private_numbers()
 
     flattened = {}
-    flattened['payload'] = jwt.decode(token_encoded, verify=False)
+    flattened['payload'] = jwt.decode(token_encoded)
     flattened['protected'] = jwt.get_unverified_header(token_encoded)
     flattened['signature'] = token_encoded.split(".")[-1]
 
@@ -105,7 +105,7 @@ def main():
     child_token_encoded = jwt.encode({"read": "/ligo/brian"}, serialized_child_private, algorithm="ES256",
                                      headers={"pwt": pwt})
     flattened = {}
-    flattened['payload'] = jwt.decode(child_token_encoded, verify=False)
+    flattened['payload'] = jwt.decode(child_token_encoded)
     flattened['protected'] = jwt.get_unverified_header(child_token_encoded)
     flattened['signature'] = child_token_encoded.split(".")[-1]
     flattened['key'] = private_jwk


### PR DESCRIPTION
This PR fixes an incompatibility with the latest release of pyjwt by removing any usage of the `verify` keyword in calls to `decode()` - it has been deprecated since pyjwt-1.1.0 (2015, https://github.com/jpadilla/pyjwt/pull/134) and ignored entirely since pyjwt-2.0.0 (https://github.com/jpadilla/pyjwt/pull/515).