### PR TITLE
Ensure compatibility with older versions of PyJWT

### DIFF
--- a/src/scitokens/scitokens.py
+++ b/src/scitokens/scitokens.py
@@ -175,7 +175,9 @@ class SciToken(object):
 
         # Encode the returned string for backwards compatibility.
         # Previous versions of PyJWT returned bytes
-        return str.encode(encoded)
+        if not isinstance(encoded, bytes):
+            encoded = str.encode(encoded)
+        return encoded
 
     def update_claims(self, claims):
         """


### PR DESCRIPTION
CentOS 8 (which comes with Python 3.6.8) ships PyJWT 1.6.1 (packaged as `python3-jwt`) in its baseos repo, which returns `bytes` when calling `jwt.encode(...)`. This change checks if the serialized token string is already bytes before trying to encode it, as encoding an already encoded string raises an error.