### PR TITLE
Reference test files using relative paths

### DIFF
--- a/tests/test_admin_create_key.py
+++ b/tests/test_admin_create_key.py
@@ -5,6 +5,7 @@ Test the admin-create-key tool
 import os
 import sys
 import unittest
+from pathlib import Path
 
 # Codacy has issues with subprocess, but this is only in the tests!
 import subprocess # nosec
@@ -21,6 +22,9 @@ if os.path.exists("../src"):
     sys.path.append("../src")
 
 from scitokens.utils import long_from_bytes
+
+TESTS_DIR = Path(__file__).parent
+
 
 class TestKeyCreate(unittest.TestCase):
     """
@@ -186,25 +190,41 @@ class TestKeyCreate(unittest.TestCase):
         """
         Test reading in the private key
         """
-        command = "{} {} --private-key=tests/simple_private_key.pem --pem-private".format(sys.executable, self.tool)
+        command = "{} {} --private-key={}/simple_private_key.pem --pem-private".format(
+            sys.executable,
+            self.tool,
+            TESTS_DIR,
+        )
         output = self._run_command(command)
         private_key = self._test_private(output)
         self.assertIsNotNone(private_key)
 
         # Test public key
-        command = "{} {} --private-key=tests/simple_private_key.pem --pem-public".format(sys.executable, self.tool)
+        command = "{} {} --private-key={}/simple_private_key.pem --pem-public".format(
+            sys.executable,
+            self.tool,
+            TESTS_DIR,
+        )
         output = self._run_command(command)
         public_key = self._test_public(output)
         self.assertIsNotNone(public_key)
 
         # Test public key
-        command = "{} {} --private-key=tests/simple_private_key.pem --jwks-private".format(sys.executable, self.tool)
+        command = "{} {} --private-key={}/simple_private_key.pem --jwks-private".format(
+            sys.executable,
+            self.tool,
+            TESTS_DIR,
+        )
         output = self._run_command(command)
         private_key = self._test_private_jwk(output)
         self.assertIsNotNone(public_key)
 
         # Test public key
-        command = "{} {} --private-key=tests/simple_private_key.pem --jwks-public".format(sys.executable, self.tool)
+        command = "{} {} --private-key={}/simple_private_key.pem --jwks-public".format(
+            sys.executable,
+            self.tool,
+            TESTS_DIR,
+        )
         output = self._run_command(command)
         public_key = self._test_public_jwk(output)
         self.assertIsNotNone(public_key)
@@ -213,25 +233,41 @@ class TestKeyCreate(unittest.TestCase):
         """
         Test reading in the private key
         """
-        command = "{} {} --ec --private-key=tests/simple_ec_private_key.pem --pem-private".format(sys.executable, self.tool)
+        command = "{} {} --ec --private-key={}/simple_ec_private_key.pem --pem-private".format(
+            sys.executable,
+            self.tool,
+            TESTS_DIR,
+        )
         output = self._run_command(command)
         private_key = self._test_private(output)
         self.assertIsNotNone(private_key)
 
         # Test public key
-        command = "{} {} --ec --private-key=tests/simple_ec_private_key.pem --pem-public".format(sys.executable, self.tool)
+        command = "{} {} --ec --private-key={}/simple_ec_private_key.pem --pem-public".format(
+            sys.executable,
+            self.tool,
+            TESTS_DIR,
+        )
         output = self._run_command(command)
         public_key = self._test_public(output)
         self.assertIsNotNone(public_key)
 
         # Test public key
-        command = "{} {} --ec --private-key=tests/simple_ec_private_key.pem --jwks-private".format(sys.executable, self.tool)
+        command = "{} {} --ec --private-key={}/simple_ec_private_key.pem --jwks-private".format(
+            sys.executable,
+            self.tool,
+            TESTS_DIR,
+        )
         output = self._run_command(command)
         private_key = self._test_ec_private_jwk(output)
         self.assertIsNotNone(public_key)
 
         # Test public key
-        command = "{} {} --ec --private-key=tests/simple_ec_private_key.pem --jwks-public".format(sys.executable, self.tool)
+        command = "{} {} --ec --private-key={}/simple_ec_private_key.pem --jwks-public".format(
+            sys.executable,
+            self.tool,
+            TESTS_DIR,
+        )
         output = self._run_command(command)
         public_key = self._test_ec_public_jwk(output)
         self.assertIsNotNone(public_key)

--- a/tests/test_with_http.py
+++ b/tests/test_with_http.py
@@ -5,6 +5,7 @@ Test the full HTTP to SciToken serialize and deserialize
 import os
 import sys
 import unittest
+from pathlib import Path
 
 # Allow unittests to be run from within the project base.
 if os.path.exists("src"):
@@ -19,13 +20,16 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from create_webserver import start_server
 
+TESTS_DIR = Path(__file__).parent
+
+
 class TestDeserialization(unittest.TestCase):
     """
     Test the deserialization of a SciToken
     """
 
     def setUp(self):
-        with open('tests/simple_private_key.pem', 'rb') as key_file:
+        with open(TESTS_DIR / 'simple_private_key.pem', 'rb') as key_file:
             self.private_key = serialization.load_pem_private_key(
                 key_file.read(),
                 password=None,
@@ -34,7 +38,7 @@ class TestDeserialization(unittest.TestCase):
         self.test_id = "stuffblah"
         self.public_numbers = self.private_key.public_key().public_numbers()
 
-        with open('tests/simple_ec_private_key.pem', 'rb') as key_file:
+        with open(TESTS_DIR / 'simple_ec_private_key.pem', 'rb') as key_file:
             self.ec_private_key = serialization.load_pem_private_key(
                 key_file.read(),
                 password=None,


### PR DESCRIPTION
This PR modifies the test functions to reference files using paths relative to the CWD, mainly to allow the test suite to be executed from any directory (including from inside the `tests/` path itself, which currently doesn't work).