### PR TITLE
Run test suite using pytest during rpmbuild

### DIFF
--- a/configs/python-scitokens.spec
+++ b/configs/python-scitokens.spec
@@ -10,10 +10,15 @@ License:        Apache 2.0
 URL:            https://scitokens.org
 Source0:        https://files.pythonhosted.org/packages/source/s/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
 BuildArch:      noarch
- 
+
+# build requirements
 BuildRequires:  python3-devel
 BuildRequires:  python%{python3_pkgversion}-setuptools
 
+# test requirements
+BuildRequires:  python%{python3_pkgversion}-cryptography
+BuildRequires:  python%{python3_pkgversion}-pytest
+BuildRequires:  python%{python3_pkgversion}-jwt >= 1.6.1
 
 %description
 SciToken reference implementation library
@@ -40,6 +45,10 @@ rm -rf %{pypi_name}.egg-info
 # Must do the subpackages' install first because the scripts in /usr/bin are
 # overwritten with every setup.py install.
 %py3_install
+
+%check
+export PYTHONPATH="%{buildroot}%{python3_sitelib}"
+(cd tests/ && %{__python3} -m pytest --verbose -ra .)
 
 %files -n python%{python3_pkgversion}-%{pypi_name}
 %license LICENSE


### PR DESCRIPTION
This PR adds a `%check` stage to the `python-scitokens.spec` file to execute the pytest suite during `rpmbuild`. This should expose problems like #129, #130, and #133 earlier in the process.

This should be rebased after #134 is merged (presuming it is merged at all).