### PR TITLE
Use shutil.move instead of os.rename

### DIFF
--- a/tests/test_create_scitoken.py
+++ b/tests/test_create_scitoken.py
@@ -324,7 +324,7 @@ class TestCreation(unittest.TestCase):
         (bt_fd, bt_tmp) = tempfile.mkstemp()
         os.close(bt_fd)
         if os.path.isfile(bt_path):
-            os.rename(bt_path, bt_tmp)
+            shutil.move(bt_path, bt_tmp)
 
         # check that the function fails properly
         with self.assertRaises(IOError):
@@ -399,7 +399,7 @@ class TestCreation(unittest.TestCase):
         os.remove(bearer_token_file)
         os.remove(bt_path)
         if os.path.isfile(bt_tmp):
-            os.rename(bt_tmp, bt_path)
+            shutil.move(bt_tmp, bt_path)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR fixes a corner-case issue in the test suite where if the user has `TMPDIR` set to a path on a different device to `/tmp` the `os.rename` operation will fail. `shutil.move` can handle that.