### PR TITLE
Add error message for when SciToken.discover doesn't find a token

### DIFF
--- a/src/scitokens/scitokens.py
+++ b/src/scitokens/scitokens.py
@@ -347,7 +347,9 @@ class SciToken(object):
                 return SciToken.deserialize(token_data,
                                             audience, require_key, insecure, public_key)
 
-        raise IOError
+        raise OSError(
+            "failed to identify a valid bearer token",
+        )
 
 
 class ValidationFailure(Exception):


### PR DESCRIPTION
This PR fixes #110 by adding an error message to the `OSError` raised when `SciToken.discover` fails to identify a token.