### PR TITLE
Fix bug decoding a token with no audience

### DIFF
--- a/src/scitokens/scitokens.py
+++ b/src/scitokens/scitokens.py
@@ -287,6 +287,7 @@ class SciToken(object):
 
         unverified_headers = jwt.get_unverified_header(serialized_jwt)
         unverified_payload = jwt.decode(serialized_jwt, algorithms=['RS256', 'ES256'],
+                                        audience=audience,
                                         options={"verify_signature": False})
         
         # Get the public key from the issuer


### PR DESCRIPTION
This PR fixes a bug exposed when running with the RHEL/EPEL7 version of PyJWT in decoding a token with `audience=None`.

EDIT: fixes #133.