### PR TITLE
Update algorithm used to test UnsupportedKeyException

### DIFF
--- a/tests/test_create_scitoken.py
+++ b/tests/test_create_scitoken.py
@@ -288,7 +288,7 @@ class TestCreation(unittest.TestCase):
 
         # Test when we give an unsupported algorithm
         unsupported_private_key = ec.generate_private_key(
-            ec.SECP192R1(), default_backend()
+            ec.SECP521R1(), default_backend()
         )
         with self.assertRaises(scitokens.scitokens.UnsupportedKeyException):
             token = scitokens.SciToken(key = unsupported_private_key)


### PR DESCRIPTION
This PR fixes #129 by updating the supported-by-cryptography-but-not-by-scitokens algorithm to supported-by-really-old-cryptography-but-still-not-by-scitokens.