### PR TITLE
Add pyproject.toml file for PEP 517 builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This file is now required for building Python packages, in the most general case.