### PR TITLE
Install requires setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setuptools.setup(
         'cryptography',
         'PyJWT>=1.6.1',
         'six',
+        'setuptools'
     ],
     # classifiers
     classifiers=[


### PR DESCRIPTION
Setuptools is a runtime dependency of scitokens because it needs pkg_resources on import.

Note, pkg_resources is deprecated and should be replaced with importlib.metadata (requires Python >= 3.8) or the backport importlib_metadata (requires Python >= 3.7).

To reproduce the issue, try installing scitokens and then importing in a clean environment (that does not have setuptools installed):

```
$ pip install scitokens
Collecting scitokens
  Downloading scitokens-1.7.0-py3-none-any.whl (23 kB)
Collecting six
  Downloading six-1.16.0-py2.py3-none-any.whl (11 kB)
Collecting cryptography
  Downloading cryptography-38.0.1-cp36-abi3-macosx_10_10_x86_64.whl (2.8 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.8/2.8 MB 12.1 MB/s eta 0:00:00
Collecting PyJWT>=1.6.1
  Using cached PyJWT-2.5.0-py3-none-any.whl (20 kB)
Collecting cffi>=1.12
  Downloading cffi-1.15.1-cp38-cp38-macosx_10_9_x86_64.whl (178 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 178.9/178.9 kB 5.4 MB/s eta 0:00:00
Collecting pycparser
  Downloading pycparser-2.21-py2.py3-none-any.whl (118 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 118.7/118.7 kB 4.1 MB/s eta 0:00:00
Installing collected packages: six, PyJWT, pycparser, cffi, cryptography, scitokens
Successfully installed PyJWT-2.5.0 cffi-1.15.1 cryptography-38.0.1 pycparser-2.21 scitokens-1.7.0 six-1.16.0
(env) gs66-wintermute:tmp lpsinger$ python -c 'import scitokens'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/private/tmp/env/lib/python3.8/site-packages/scitokens/__init__.py", line 6, in <module>
    from .scitokens import SciToken, Validator, Enforcer, MissingClaims
  File "/private/tmp/env/lib/python3.8/site-packages/scitokens/scitokens.py", line 21, in <module>
    from .utils import keycache as KeyCache
  File "/private/tmp/env/lib/python3.8/site-packages/scitokens/utils/keycache.py", line 9, in <module>
    import pkg_resources  # part of setuptools
ModuleNotFoundError: No module named 'pkg_resources'
```