### PR TITLE
Add configuration for readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,17 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+sphinx:
+  builder: html
+  configuration: docs/source/conf.py
+
+python:
+  version: "3"
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,11 @@ setuptools.setup(
         'PyJWT>=1.6.1',
         'six',
     ],
+    extras_require={
+        "docs": [
+            "Sphinx",
+        ],
+    },
     # classifiers
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
This PR adds a configuration file for ReadTheDocs, and adds a `[docs]` extra in setup.py to support it.