### PR TITLE
Fix missing issuer problem in deserialize function

### DIFF
--- a/src/scitokens/scitokens.py
+++ b/src/scitokens/scitokens.py
@@ -295,6 +295,9 @@ class SciToken(object):
         # Get the public key from the issuer
         keycache = KeyCache.KeyCache().getinstance()
         if public_key == None:
+            if 'iss' not in unverified_payload:
+                raise MissingIssuerException('Issuer not provided')
+
             issuer_public_key = keycache.getkeyinfo(unverified_payload['iss'],
                                 key_id=unverified_headers['kid'] if 'kid' in unverified_headers else None,
                                 insecure=insecure)

--- a/tests/test_create_scitoken.py
+++ b/tests/test_create_scitoken.py
@@ -14,6 +14,7 @@ if os.path.exists("src"):
 if os.path.exists("../src"):
     sys.path.append("../src")
 
+import jwt
 import scitokens
 from cryptography.hazmat.primitives.asymmetric.rsa import generate_private_key
 import cryptography.hazmat.primitives.asymmetric.ec as ec
@@ -418,6 +419,29 @@ class TestCreation(unittest.TestCase):
         os.remove(bt_path)
         if os.path.isfile(bt_tmp):
             shutil.move(bt_tmp, bt_path)
+
+    def test_noiss(self):
+        """
+        Verify that tokens without the `iss` are not accepted.
+        """
+        encoded_jwt = jwt.encode(
+            {
+                "ver": "scitoken:2.0",
+                "aud": "https://demo.scitokens.org",
+                "exp": 1668462237,
+                "iat": 1668461637,
+                "nbf": 1668461637,
+                "jti": "eab04181-b63a-42aa-b77d-804742829fc5",
+                "kid": "key-rs256"
+            },
+            "secret",
+            algorithm="HS256",
+            headers={"typ": "JWT", "alg": "HS256", "kid": "key-hs256"}
+        )
+
+        # Test when we give it without issuer
+        with self.assertRaises(scitokens.scitokens.MissingIssuerException):
+            stoken = scitokens.SciToken.deserialize(encoded_jwt)
 
 
 if __name__ == '__main__':

--- a/tests/test_create_scitoken.py
+++ b/tests/test_create_scitoken.py
@@ -7,6 +7,7 @@ import sys
 import unittest
 import tempfile
 import shutil
+import datetime
 
 # Allow unittests to be run from within the project base.
 if os.path.exists("src"):

--- a/tests/test_create_scitoken.py
+++ b/tests/test_create_scitoken.py
@@ -8,6 +8,7 @@ import unittest
 import tempfile
 import shutil
 import datetime
+import datetime.timezone as timezone
 
 # Allow unittests to be run from within the project base.
 if os.path.exists("src"):

--- a/tests/test_create_scitoken.py
+++ b/tests/test_create_scitoken.py
@@ -8,7 +8,6 @@ import unittest
 import tempfile
 import shutil
 import datetime
-import datetime.timezone as timezone
 
 # Allow unittests to be run from within the project base.
 if os.path.exists("src"):
@@ -430,9 +429,9 @@ class TestCreation(unittest.TestCase):
             {
                 "ver": "scitoken:2.0",
                 "aud": "https://demo.scitokens.org",
-                "exp": datetime.datetime.now(tz=timezone.utc) + datetime.timedelta(seconds=30),
-                "iat": datetime.datetime.now(tz=timezone.utc),
-                "nbf": datetime.datetime.now(tz=timezone.utc),
+                "exp": datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(seconds=30),
+                "iat": datetime.datetime.now(tz=datetime.timezone.utc),
+                "nbf": datetime.datetime.now(tz=datetime.timezone.utc),
                 "jti": "eab04181-b63a-42aa-b77d-804742829fc5",
                 "kid": "key-rs256"
             },

--- a/tests/test_create_scitoken.py
+++ b/tests/test_create_scitoken.py
@@ -441,7 +441,7 @@ class TestCreation(unittest.TestCase):
 
         # Test when we give it without issuer
         with self.assertRaises(scitokens.scitokens.MissingIssuerException):
-            stoken = scitokens.SciToken.deserialize(encoded_jwt)
+           scitokens.SciToken.deserialize(encoded_jwt)
 
 
 if __name__ == '__main__':

--- a/tests/test_create_scitoken.py
+++ b/tests/test_create_scitoken.py
@@ -428,9 +428,9 @@ class TestCreation(unittest.TestCase):
             {
                 "ver": "scitoken:2.0",
                 "aud": "https://demo.scitokens.org",
-                "exp": 1668462237,
-                "iat": 1668461637,
-                "nbf": 1668461637,
+                "exp": datetime.datetime.now(tz=timezone.utc) + datetime.timedelta(seconds=30),
+                "iat": datetime.datetime.now(tz=timezone.utc),
+                "nbf": datetime.datetime.now(tz=timezone.utc),
                 "jti": "eab04181-b63a-42aa-b77d-804742829fc5",
                 "kid": "key-rs256"
             },


### PR DESCRIPTION
The deserialize function should raise the MissingIssuerException in case issuer is not provided. This commit fixed the issue. Also, added the unittest for this change.