### PR TITLE
Fix issue in creating the cache file location

### DIFF
--- a/src/scitokens/utils/keycache.py
+++ b/src/scitokens/utils/keycache.py
@@ -340,8 +340,11 @@ class KeyCache(object):
                 raise UnableToCreateCache("Unable to create cache: {}".format(str(ose)))
 
         keycache_dir = os.path.join(cache_dir, "scitokens")
-        if not os.path.exists(keycache_dir):
-            os.makedirs(keycache_dir)
+        try:
+            if not os.path.exists(keycache_dir):
+                os.makedirs(keycache_dir)
+        except OSError as ose:
+            raise UnableToCreateCache("Unable to create cache: {}".format(str(ose)))
 
         keycache_file = os.path.join(keycache_dir, CACHE_FILENAME)
         if not os.path.exists(keycache_file):

--- a/tests/test_keycache.py
+++ b/tests/test_keycache.py
@@ -62,13 +62,20 @@ class TestKeyCache(unittest.TestCase):
             del keycache
 
     @unittest.skipIf(sys.platform.startswith("win"), "Test doesn't work on Windows")
-    @unittest.skipIf(sys.platform.startswith("fed"), "Test doesn't work on Fedora")
-    @unittest.skipIf(sys.platform.startswith("cent"), "Test doesn't work on CentOS")
     def test_cannot_make_cache_permission_denied(self):
         """
         Test when the keycache shouldn't be able to make the cache due to access privilege
         """
         os.environ['XDG_CACHE_HOME'] = self.tmp_dir
+        # print("self.tmp_dir: {}".format(self.tmp_dir))
+        # shutil.rmtree(os.path.join(self.tmp_dir, "scitokens"))
+        for filename in os.listdir(os.path.join(self.tmp_dir, "scitokens")):
+            filepath = os.path.join(os.path.join(self.tmp_dir, "scitokens"), filename)
+            # print(">>>> filepath: {}".format(filepath))
+            try:
+                shutil.rmtree(filepath)
+            except OSError:
+                os.remove(filepath)
 
         # Limiting access privilege to read-only for the $XDG_CACHE_HOME
         os.chmod(

--- a/tests/test_keycache.py
+++ b/tests/test_keycache.py
@@ -3,6 +3,7 @@ Test the keycache
 """
 
 import os, stat
+import sys
 import tempfile
 import shutil
 import unittest

--- a/tests/test_keycache.py
+++ b/tests/test_keycache.py
@@ -61,7 +61,9 @@ class TestKeyCache(unittest.TestCase):
             keycache = KeyCache()
             del keycache
 
-    @unittest.skipIf(sys.platform.startswith("win"), "Test doesn't work on windows")
+    @unittest.skipIf(sys.platform.startswith("win"), "Test doesn't work on Windows")
+    @unittest.skipIf(sys.platform.startswith("fed"), "Test doesn't work on Fedora")
+    @unittest.skipIf(sys.platform.startswith("cent"), "Test doesn't work on CentOS")
     def test_cannot_make_cache_permission_denied(self):
         """
         Test when the keycache shouldn't be able to make the cache due to access privilege

--- a/tests/test_keycache.py
+++ b/tests/test_keycache.py
@@ -68,15 +68,6 @@ class TestKeyCache(unittest.TestCase):
         Test when the keycache shouldn't be able to make the cache due to access privilege
         """
         os.environ['XDG_CACHE_HOME'] = self.tmp_dir
-        # print("self.tmp_dir: {}".format(self.tmp_dir))
-        # shutil.rmtree(os.path.join(self.tmp_dir, "scitokens"))
-        for filename in os.listdir(os.path.join(self.tmp_dir, "scitokens")):
-            filepath = os.path.join(os.path.join(self.tmp_dir, "scitokens"), filename)
-            # print(">>>> filepath: {}".format(filepath))
-            try:
-                shutil.rmtree(filepath)
-            except OSError:
-                os.remove(filepath)
 
         # Limiting access privilege to read-only for the $XDG_CACHE_HOME
         os.chmod(

--- a/tests/test_keycache.py
+++ b/tests/test_keycache.py
@@ -60,6 +60,7 @@ class TestKeyCache(unittest.TestCase):
             keycache = KeyCache()
             del keycache
 
+    @unittest.skipIf(sys.platform.startswith("win"), "Test doesn't work on windows")
     def test_cannot_make_cache_permission_denied(self):
         """
         Test when the keycache shouldn't be able to make the cache due to access privilege

--- a/tests/test_keycache.py
+++ b/tests/test_keycache.py
@@ -62,7 +62,7 @@ class TestKeyCache(unittest.TestCase):
             del keycache
 
     @unittest.skipIf(sys.platform.startswith("win"), "Test doesn't work on Windows")
-    @unittest.skipIf(not sys.platform.startswith("win") && os.getuid() == 0, "Test doesn't work when root")
+    @unittest.skipIf(not sys.platform.startswith("win") and os.getuid() == 0, "Test doesn't work when root")
     def test_cannot_make_cache_permission_denied(self):
         """
         Test when the keycache shouldn't be able to make the cache due to access privilege

--- a/tests/test_keycache.py
+++ b/tests/test_keycache.py
@@ -62,7 +62,7 @@ class TestKeyCache(unittest.TestCase):
             del keycache
 
     @unittest.skipIf(sys.platform.startswith("win"), "Test doesn't work on Windows")
-    @unittest.skipIf(os.getuid() == 0, "Test doesn't work when root")
+    @unittest.skipIf(!sys.platform.startswith("win") && os.getuid() == 0, "Test doesn't work when root")
     def test_cannot_make_cache_permission_denied(self):
         """
         Test when the keycache shouldn't be able to make the cache due to access privilege

--- a/tests/test_keycache.py
+++ b/tests/test_keycache.py
@@ -61,19 +61,23 @@ class TestKeyCache(unittest.TestCase):
             keycache = KeyCache()
             del keycache
 
-    @unittest.skipIf(sys.platform.startswith("win"), "Test doesn't work on windows")
+    # @unittest.skipIf(sys.platform.startswith("win"), "Test doesn't work on windows")
     def test_cannot_make_cache_permission_denied(self):
         """
         Test when the keycache shouldn't be able to make the cache due to access privilege
         """
         os.environ['XDG_CACHE_HOME'] = self.tmp_dir
+        mode = os.stat(self.tmp_dir).st_mode
+        # ro_mask = 0o777 ^ (stat.S_IWRITE | stat.S_IWGRP | stat.S_IWOTH)
 
         # Limiting access privilege to read-only for the $XDG_CACHE_HOME
         os.chmod(
             self.tmp_dir,
-            stat.S_IRUSR |  # Read for user
-            stat.S_IRGRP |  # Read for group
-            stat.S_IROTH    # Read for other
+            0o444
+            # mode & ro_mask
+            # stat.S_IRUSR |  # Read for user
+            # stat.S_IRGRP |  # Read for group
+            # stat.S_IROTH    # Read for other
         )
 
         # Make sure it raises an unable to create cache exception
@@ -84,9 +88,10 @@ class TestKeyCache(unittest.TestCase):
         # Revert the access privilege alteration for the $XDG_CACHE_HOME
         os.chmod(
             self.tmp_dir,
-            stat.S_IRWXU |  # Read, write, and execute for user
-            stat.S_IRWXG |  # Read, write, and execute for group
-            stat.S_IRWXO    # Read, write, and execute for other
+            mode
+            # stat.S_IRWXU |  # Read, write, and execute for user
+            # stat.S_IRWXG |  # Read, write, and execute for group
+            # stat.S_IRWXO    # Read, write, and execute for other
         )
 
     def test_empty(self):

--- a/tests/test_keycache.py
+++ b/tests/test_keycache.py
@@ -60,7 +60,7 @@ class TestKeyCache(unittest.TestCase):
             keycache = KeyCache()
             del keycache
 
-    def test_cannot_make_cache(self):
+    def test_cannot_make_cache_permission_denied(self):
         """
         Test when the keycache shouldn't be able to make the cache due to access privilege
         """

--- a/tests/test_keycache.py
+++ b/tests/test_keycache.py
@@ -61,23 +61,19 @@ class TestKeyCache(unittest.TestCase):
             keycache = KeyCache()
             del keycache
 
-    # @unittest.skipIf(sys.platform.startswith("win"), "Test doesn't work on windows")
+    @unittest.skipIf(sys.platform.startswith("win"), "Test doesn't work on windows")
     def test_cannot_make_cache_permission_denied(self):
         """
         Test when the keycache shouldn't be able to make the cache due to access privilege
         """
         os.environ['XDG_CACHE_HOME'] = self.tmp_dir
-        mode = os.stat(self.tmp_dir).st_mode
-        # ro_mask = 0o777 ^ (stat.S_IWRITE | stat.S_IWGRP | stat.S_IWOTH)
 
         # Limiting access privilege to read-only for the $XDG_CACHE_HOME
         os.chmod(
             self.tmp_dir,
-            0o444
-            # mode & ro_mask
-            # stat.S_IRUSR |  # Read for user
-            # stat.S_IRGRP |  # Read for group
-            # stat.S_IROTH    # Read for other
+            stat.S_IRUSR |  # Read for user
+            stat.S_IRGRP |  # Read for group
+            stat.S_IROTH    # Read for other
         )
 
         # Make sure it raises an unable to create cache exception
@@ -88,10 +84,9 @@ class TestKeyCache(unittest.TestCase):
         # Revert the access privilege alteration for the $XDG_CACHE_HOME
         os.chmod(
             self.tmp_dir,
-            mode
-            # stat.S_IRWXU |  # Read, write, and execute for user
-            # stat.S_IRWXG |  # Read, write, and execute for group
-            # stat.S_IRWXO    # Read, write, and execute for other
+            stat.S_IRWXU |  # Read, write, and execute for user
+            stat.S_IRWXG |  # Read, write, and execute for group
+            stat.S_IRWXO    # Read, write, and execute for other
         )
 
     def test_empty(self):

--- a/tests/test_keycache.py
+++ b/tests/test_keycache.py
@@ -62,7 +62,7 @@ class TestKeyCache(unittest.TestCase):
             del keycache
 
     @unittest.skipIf(sys.platform.startswith("win"), "Test doesn't work on Windows")
-    @unittest.skipIf(!sys.platform.startswith("win") && os.getuid() == 0, "Test doesn't work when root")
+    @unittest.skipIf(not sys.platform.startswith("win") && os.getuid() == 0, "Test doesn't work when root")
     def test_cannot_make_cache_permission_denied(self):
         """
         Test when the keycache shouldn't be able to make the cache due to access privilege

--- a/tests/test_keycache.py
+++ b/tests/test_keycache.py
@@ -62,6 +62,7 @@ class TestKeyCache(unittest.TestCase):
             del keycache
 
     @unittest.skipIf(sys.platform.startswith("win"), "Test doesn't work on Windows")
+    @unittest.skipIf(os.getuid() == 0, "Test doesn't work when root")
     def test_cannot_make_cache_permission_denied(self):
         """
         Test when the keycache shouldn't be able to make the cache due to access privilege

--- a/tests/test_keycache.py
+++ b/tests/test_keycache.py
@@ -2,7 +2,7 @@
 Test the keycache
 """
 
-import os
+import os, stat
 import tempfile
 import shutil
 import unittest
@@ -59,6 +59,33 @@ class TestKeyCache(unittest.TestCase):
         with self.assertRaises(UnableToCreateCache):
             keycache = KeyCache()
             del keycache
+
+    def test_cannot_make_cache(self):
+        """
+        Test when the keycache shouldn't be able to make the cache due to access privilege
+        """
+        os.environ['XDG_CACHE_HOME'] = self.tmp_dir
+
+        # Limiting access privilege to read-only for the $XDG_CACHE_HOME
+        os.chmod(
+            self.tmp_dir,
+            stat.S_IRUSR |  # Read for user
+            stat.S_IRGRP |  # Read for group
+            stat.S_IROTH    # Read for other
+        )
+
+        # Make sure it raises an unable to create cache exception
+        with self.assertRaises(UnableToCreateCache):
+            keycache = KeyCache()
+            del keycache
+
+        # Revert the access privilege alteration for the $XDG_CACHE_HOME
+        os.chmod(
+            self.tmp_dir,
+            stat.S_IRWXU |  # Read, write, and execute for user
+            stat.S_IRWXG |  # Read, write, and execute for group
+            stat.S_IRWXO    # Read, write, and execute for other
+        )
 
     def test_empty(self):
         """
@@ -233,3 +260,5 @@ class TestKeyCache(unittest.TestCase):
 
         create_webserver.shutdown_server()
 
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Cache file directory creation requires to be done under try-catch block. This commit has fixed the issue. Also, added the unittest for this change.