### PR TITLE
Use importlib.metadata rather than pkg_resources

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 cryptography
+importlib_metadata;python_version<'3.8'
 PyJWT>=2.2.0

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setuptools.setup(
     install_requires=[
         'cryptography',
         'PyJWT>=1.6.1',
+        "importlib_metadata;python_version<'3.8'",
         'setuptools'
     ],
     extras_require={

--- a/src/scitokens/utils/keycache.py
+++ b/src/scitokens/utils/keycache.py
@@ -6,12 +6,17 @@ A module for effectively caching the public keys of various token issuer endpoin
 import os
 import sqlite3
 import time
-import pkg_resources  # part of setuptools
 import re
 import logging
+
 try:
-    PKG_VERSION = pkg_resources.require("scitokens")[0].version
-except pkg_resources.DistributionNotFound as error:
+    import importlib.metadata as import_meta
+except ImportError:
+    import importlib_metadata as import_meta
+
+try:
+    PKG_VERSION = import_meta.version("scitokens")
+except import_meta.PackageNotFoundError:
     # During testing, scitokens won't be installed, so requiring it will fail
     # Instead, fake it
     PKG_VERSION = '1.0.0'


### PR DESCRIPTION
pkg_resources is a deprecated API, and a rather heavyweight one. Since Python 3.8, the standard library has included importlib.metadata, which can do the same functionality we're looking for here. Since we continue to support older versions of Python, fallback to importlib_metadata if required.