### PR TITLE
Don't use pkg_resources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,6 @@ setuptools.setup(
     install_requires=[
         'cryptography',
         'PyJWT>=1.6.1',
-        'setuptools',
         'requests'
     ],
     extras_require={

--- a/src/scitokens/__init__.py
+++ b/src/scitokens/__init__.py
@@ -3,7 +3,7 @@
 Module for creating and using SciTokens.
 """
 
+__version__ = "1.7.5"
+
 from .scitokens import SciToken, Validator, Enforcer, MissingClaims
 from .utils.config import set_config
-
-__version__ = "1.7.5"

--- a/src/scitokens/utils/keycache.py
+++ b/src/scitokens/utils/keycache.py
@@ -6,15 +6,8 @@ A module for effectively caching the public keys of various token issuer endpoin
 import os
 import sqlite3
 import time
-import pkg_resources  # part of setuptools
 import re
 import logging
-try:
-    PKG_VERSION = pkg_resources.require("scitokens")[0].version
-except pkg_resources.DistributionNotFound as error:
-    # During testing, scitokens won't be installed, so requiring it will fail
-    # Instead, fake it
-    PKG_VERSION = '1.0.0'
 
 try:
     import urllib.request as request
@@ -36,6 +29,7 @@ from scitokens.utils.errors import SciTokensException, MissingKeyException, NonH
 from scitokens.utils import long_from_bytes
 import scitokens.utils.config as config
 
+from .. import __version__ as PKG_VERSION
 
 CACHE_FILENAME = "scitokens_keycache.sqllite"
 KEYCACHE_INSTANCE = None


### PR DESCRIPTION
This PR removes the use of `pkg_resources`, which has been deprecated. For the current use case, I used the simplest alternative of just importing the version metadata from the top-level dunder variable.