### PR TITLE
Adding pytest integration to turn of networking tests

### DIFF
--- a/configs/python-scitokens.spec
+++ b/configs/python-scitokens.spec
@@ -52,9 +52,9 @@ rm -rf %{pypi_name}.egg-info
 %check
 %if 0%{?rhel} == 7
 export PYTHONPATH="%{buildroot}%{python3_sitelib}"
-(cd tests/ && %{__python3} -m pytest --verbose -ra .)
+(cd tests/ && %{__python3} -m pytest --verbose -ra . --no-network)
 %else
-%pytest --verbose -ra tests/
+%pytest --verbose -ra tests/ --no-network
 %endif
 
 %files -n python3-%{pypi_name}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--no-network", action="store_true", default=False, help="Skip network tests"
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "network: mark test as needing network")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--no-network"):
+        skip_network = pytest.mark.skip(reason="Need network access to run and --no-network specified")
+        for item in items:
+            if "network" in item.keywords:
+                item.add_marker(skip_network)
+        

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -6,9 +6,12 @@ import scitokens.utils.demo
 import unittest
 import jwt          # to handle jwt exceptions
 import time         # to add time delay
+import pytest       # to skip tests
 
 
 class TestToken(unittest.TestCase):
+
+    @pytest.mark.network
     def test_valid_payload(self):
         """
         Test that the token matches the specified payload
@@ -29,7 +32,7 @@ class TestToken(unittest.TestCase):
         for key, value in payload.items():
             self.assertIn((key, value), token.claims())
 
-
+    @pytest.mark.network
     def test_empty_payload(self):
         """
         Test token with empty payload
@@ -45,6 +48,7 @@ class TestToken(unittest.TestCase):
 
 
 class TestParsedToken(unittest.TestCase):
+    @pytest.mark.network
     def test_valid_parsed(self):
         """
         Test that the parsed token matches the payload
@@ -62,7 +66,7 @@ class TestParsedToken(unittest.TestCase):
         for key, value in payload.items():
             self.assertIn((key, value), token.claims())
 
-
+    @pytest.mark.network
     def test_empty_parsed(self):
         """
         Test token with empty payload


### PR DESCRIPTION
Use the pytest --no-network option to turn off tests that require outgoing network access.