### PR TITLE
Create simple CLI tool to examine keycache in Python and refresh all entries in keycache

### DIFF
--- a/src/scitokens/tools/admin_add_key.py
+++ b/src/scitokens/tools/admin_add_key.py
@@ -13,10 +13,8 @@ def add_args():
 
 def main():
     args = add_args()
-    
     keycache = KeyCache()
     res = keycache.add_key(args.issuer, args.key_id)
-    
     if res != None:
         print("Successfully added token with issuer = {} and key_id = {}!".format(args.issuer, args.key_id))
         print(res)

--- a/src/scitokens/tools/admin_add_key.py
+++ b/src/scitokens/tools/admin_add_key.py
@@ -1,0 +1,1 @@
+# Similar to remove

--- a/src/scitokens/tools/admin_add_key.py
+++ b/src/scitokens/tools/admin_add_key.py
@@ -23,5 +23,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-    
-

--- a/src/scitokens/tools/admin_add_key.py
+++ b/src/scitokens/tools/admin_add_key.py
@@ -1,1 +1,29 @@
-# Similar to remove
+import argparse
+from scitokens.utils.keycache import KeyCache
+
+def add_args():
+    """
+    Generate the ArgumentParser object for the CLI.
+    """
+    parser = argparse.ArgumentParser(description='Remove a local cached token')
+    parser.add_argument('issuer', help='issuer')
+    parser.add_argument('key_id', help='key_id')
+    args = parser.parse_args()
+    return args
+
+def main():
+    args = add_args()
+    
+    keycache = KeyCache()
+    res = keycache.add_token(args.issuer, args.key_id)
+    
+    if res != None:
+        print("Successfully added token with issuer = {} and key_id = {}!".format(args.issuer, args.key_id))
+        print(res)
+    else:
+        print("Invalid issuer = {} and key_id = {} !".format(args.issuer, args.key_id))
+
+if __name__ == "__main__":
+    main()
+    
+

--- a/src/scitokens/tools/admin_add_key.py
+++ b/src/scitokens/tools/admin_add_key.py
@@ -15,7 +15,7 @@ def main():
     args = add_args()
     
     keycache = KeyCache()
-    res = keycache.add_token(args.issuer, args.key_id)
+    res = keycache.add_key(args.issuer, args.key_id)
     
     if res != None:
         print("Successfully added token with issuer = {} and key_id = {}!".format(args.issuer, args.key_id))

--- a/src/scitokens/tools/admin_list_key.py
+++ b/src/scitokens/tools/admin_list_key.py
@@ -3,7 +3,7 @@ from scitokens.utils.keycache import KeyCache
 def main():
     # TODO: Make this work
     keycache = KeyCache()
-    res = keycache.list_token(keycache._get_cache_file())
+    res = keycache.list_token()
     
     header = ["issuer", "expiration", "key_id", "keydata", "next_update"]
     

--- a/src/scitokens/tools/admin_list_key.py
+++ b/src/scitokens/tools/admin_list_key.py
@@ -1,0 +1,16 @@
+from scitokens.utils.keycache import KeyCache
+
+def main():
+    # TODO: Make this work
+    keycache = KeyCache()
+    res = keycache.list_token(keycache._get_cache_file())
+    
+    header = ["issuer", "expiration", "key_id", "keydata", "next_update"]
+    
+    print("{:<30} | {:<25} | {:<40} | {:<20} | {}".format(header[0], header[1], header[2], header[3], header[4]))
+    print("-" * 150)
+    for record in res:
+        print("{:<30} | {:<25} | {:<40} | {:<20} | {}".format(record[0], record[1], record[2], record[3][:20], record[4]))
+
+if __name__ == "__main__":
+    main()

--- a/src/scitokens/tools/admin_list_key.py
+++ b/src/scitokens/tools/admin_list_key.py
@@ -7,10 +7,10 @@ def main():
     
     header = ["issuer", "expiration", "key_id", "keydata", "next_update"]
     
-    print("{:<30} | {:<25} | {:<40} | {:<20} | {}".format(header[0], header[1], header[2], header[3], header[4]))
-    print("-" * 150)
+    print("{:<30} | {:<19} | {:<35} | {:<20} | {}".format(header[0], header[1], header[2], header[3], header[4]))
+    print("-" * 135)
     for record in res:
-        print("{:<30} | {:<25} | {:<40} | {:<20} | {}".format(record[0], record[1], record[2], record[3][:20], record[4]))
+        print("{:<30} | {:<19} | {:<35} | {:<20} | {}".format(record[0], record[1], record[2], record[3][:20], record[4]))
 
 if __name__ == "__main__":
     main()

--- a/src/scitokens/tools/admin_list_keys.py
+++ b/src/scitokens/tools/admin_list_keys.py
@@ -4,9 +4,7 @@ def main():
     # TODO: Make this work
     keycache = KeyCache()
     res = keycache.list_key()
-    
     header = ["issuer", "expiration", "key_id", "keydata", "next_update"]
-    
     print("{:<30} | {:<19} | {:<35} | {:<20} | {}".format(header[0], header[1], header[2], header[3], header[4]))
     print("-" * 135)
     for record in res:

--- a/src/scitokens/tools/admin_list_keys.py
+++ b/src/scitokens/tools/admin_list_keys.py
@@ -3,7 +3,7 @@ from scitokens.utils.keycache import KeyCache
 def main():
     # TODO: Make this work
     keycache = KeyCache()
-    res = keycache.list_key()
+    res = keycache.list_keys()
     header = ["issuer", "expiration", "key_id", "keydata", "next_update"]
     print("{:<30} | {:<19} | {:<35} | {:<20} | {}".format(header[0], header[1], header[2], header[3], header[4]))
     print("-" * 135)

--- a/src/scitokens/tools/admin_list_keys.py
+++ b/src/scitokens/tools/admin_list_keys.py
@@ -3,7 +3,7 @@ from scitokens.utils.keycache import KeyCache
 def main():
     # TODO: Make this work
     keycache = KeyCache()
-    res = keycache.list_token()
+    res = keycache.list_key()
     
     header = ["issuer", "expiration", "key_id", "keydata", "next_update"]
     

--- a/src/scitokens/tools/admin_remove_key.py
+++ b/src/scitokens/tools/admin_remove_key.py
@@ -1,0 +1,26 @@
+import argparse
+from scitokens.utils.keycache import KeyCache
+
+def add_args():
+    """
+    Generate the ArgumentParser object for the CLI.
+    """
+    parser = argparse.ArgumentParser(description='Remove a local cached token')
+    parser.add_argument('issuer', help='issuer')
+    parser.add_argument('key_id', help='key_id')
+    args = parser.parse_args()
+    return args
+
+def main():
+    args = add_args()
+    
+    keycache = KeyCache()
+    res = keycache.remove_token(keycache._get_cache_file(), args.issuer, args.key_id)
+    
+    if res == True:
+        print("Successfully deleted token with issuer = {} and key_id = {}!".format(args.issuer, args.key_id))
+    else:
+        print("Token with issuer = {} and key_id = {} does NOT exist!".format(args.issuer, args.key_id))
+
+if __name__ == "__main__":
+    main()

--- a/src/scitokens/tools/admin_remove_key.py
+++ b/src/scitokens/tools/admin_remove_key.py
@@ -13,10 +13,8 @@ def add_args():
 
 def main():
     args = add_args()
-    
     keycache = KeyCache()
     res = keycache.remove_key(args.issuer, args.key_id)
-    
     if res == True:
         print("Successfully deleted token with issuer = {} and key_id = {}!".format(args.issuer, args.key_id))
     else:

--- a/src/scitokens/tools/admin_remove_key.py
+++ b/src/scitokens/tools/admin_remove_key.py
@@ -15,7 +15,7 @@ def main():
     args = add_args()
     
     keycache = KeyCache()
-    res = keycache.remove_token(keycache._get_cache_file(), args.issuer, args.key_id)
+    res = keycache.remove_token(args.issuer, args.key_id)
     
     if res == True:
         print("Successfully deleted token with issuer = {} and key_id = {}!".format(args.issuer, args.key_id))

--- a/src/scitokens/tools/admin_remove_key.py
+++ b/src/scitokens/tools/admin_remove_key.py
@@ -15,7 +15,7 @@ def main():
     args = add_args()
     
     keycache = KeyCache()
-    res = keycache.remove_token(args.issuer, args.key_id)
+    res = keycache.remove_key(args.issuer, args.key_id)
     
     if res == True:
         print("Successfully deleted token with issuer = {} and key_id = {}!".format(args.issuer, args.key_id))

--- a/src/scitokens/tools/admin_update_keys.py
+++ b/src/scitokens/tools/admin_update_keys.py
@@ -12,10 +12,8 @@ def add_args():
 
 def main():
     args = add_args()
-    
     keycache = KeyCache()
     res = keycache.update_all_keys(force_refresh=args.force)
-    
     for i in res:
         print(i)
 

--- a/src/scitokens/tools/admin_update_keys.py
+++ b/src/scitokens/tools/admin_update_keys.py
@@ -11,11 +11,10 @@ def add_args():
     return args
 
 def main():
-    # TODO: Make this work
-    keycache = KeyCache()
-    
     args = add_args()
-    res = keycache.update_all_tokens(force_refresh=args.force)
+    
+    keycache = KeyCache()
+    res = keycache.update_all_keys(force_refresh=args.force)
     
     for i in res:
         print(i)

--- a/src/scitokens/tools/admin_update_keys.py
+++ b/src/scitokens/tools/admin_update_keys.py
@@ -1,0 +1,1 @@
+# Refresh all the entries in the database

--- a/src/scitokens/tools/admin_update_keys.py
+++ b/src/scitokens/tools/admin_update_keys.py
@@ -1,12 +1,26 @@
+import argparse
 from scitokens.utils.keycache import KeyCache
+
+def add_args():
+    """
+    Generate the ArgumentParser object for the CLI.
+    """
+    parser = argparse.ArgumentParser(description='Update all tokens in the cache')
+    parser.add_argument('-f', '--force', action='store_true', help='Force refresh all tokens')
+    args = parser.parse_args()
+    return args
 
 def main():
     # TODO: Make this work
     keycache = KeyCache()
-    res = keycache.update_all_tokens()
+    
+    args = add_args()
+    res = keycache.update_all_tokens(force_refresh=args.force)
     
     for i in res:
         print(i)
 
 if __name__ == "__main__":
     main()
+
+

--- a/src/scitokens/tools/admin_update_keys.py
+++ b/src/scitokens/tools/admin_update_keys.py
@@ -1,1 +1,12 @@
-# Refresh all the entries in the database
+from scitokens.utils.keycache import KeyCache
+
+def main():
+    # TODO: Make this work
+    keycache = KeyCache()
+    res = keycache.update_all_tokens()
+    
+    for i in res:
+        print(i)
+
+if __name__ == "__main__":
+    main()

--- a/src/scitokens/utils/keycache.py
+++ b/src/scitokens/utils/keycache.py
@@ -369,3 +369,30 @@ class KeyCache(object):
         # We can also close the connection if we are done with it.
         # Just be sure any changes have been committed or they will be lost.
         conn.close()
+
+    @staticmethod
+    def list_token(sql_file):
+        conn = sqlite3.connect(sql_file)
+        curs = conn.cursor()
+        
+        res = curs.execute("SELECT * FROM keycache")
+        tokens = res.fetchall()
+        
+        conn.close()
+        return tokens
+    
+    @staticmethod
+    def remove_token(sql_file, issuer, key_id):
+        conn = sqlite3.connect(sql_file)
+        curs = conn.cursor()
+        
+        res = curs.execute("SELECT * FROM keycache WHERE issuer = ? AND key_id = ?", [issuer, key_id])
+        if res.fetchone() is None:
+            conn.close()
+            return False
+        
+        res = curs.execute("DELETE FROM keycache WHERE issuer = ? AND key_id = ?", [issuer, key_id])
+        res = curs.fetchall()
+        conn.commit()
+        conn.close()
+        return True

--- a/src/scitokens/utils/keycache.py
+++ b/src/scitokens/utils/keycache.py
@@ -379,7 +379,7 @@ class KeyCache(object):
         conn.close()
 
 
-    def list_key(self):
+    def list_keys(self):
         """
         List all keys in keycache
         """

--- a/src/scitokens/utils/keycache.py
+++ b/src/scitokens/utils/keycache.py
@@ -379,7 +379,10 @@ class KeyCache(object):
         conn.close()
 
 
-    def list_token(self):
+    def list_key(self):
+        """
+        List all keys in keycache
+        """
         conn = sqlite3.connect(self._get_cache_file())
         curs = conn.cursor()
         res = curs.execute("SELECT issuer, DATETIME(expiration, 'unixepoch'), key_id, keydata, DATETIME(next_update, 'unixepoch') FROM keycache")
@@ -389,7 +392,10 @@ class KeyCache(object):
         return tokens
     
 
-    def remove_token(self, issuer, key_id):
+    def remove_key(self, issuer, key_id):
+        """
+        Remove a specific key from keycache
+        """
         conn = sqlite3.connect(self._get_cache_file())
         curs = conn.cursor()
         
@@ -405,7 +411,10 @@ class KeyCache(object):
         return True
 
 
-    def add_token(self, issuer, key_id, force_refresh=False):
+    def add_key(self, issuer, key_id, force_refresh=False):
+        """
+        Add a key or update an existing one in keycache
+        """
         pubkey = self.getkeyinfo(issuer, key_id, force_refresh=force_refresh)
         if pubkey is None:
             return None
@@ -417,7 +426,11 @@ class KeyCache(object):
         return pubkey_pem
     
 
-    def update_all_tokens(self, force_refresh=False):
+    def update_all_keys(self, force_refresh=False):
+        """
+        Update all keys in keycache
+        If force_refresh is True, we refresh all keys regardless of update time
+        """
         conn = sqlite3.connect(self._get_cache_file())
         curs = conn.cursor()
         res = curs.execute("SELECT issuer, key_id FROM keycache")
@@ -426,6 +439,6 @@ class KeyCache(object):
         
         res = []
         for issuer, key_id in tokens:
-            updated = self.add_token(issuer, key_id, force_refresh=force_refresh)
+            updated = self.add_key(issuer, key_id, force_refresh=force_refresh)
             res.append(updated)
         return res


### PR DESCRIPTION
Outputs the contents of the database
- List / Add / Remove records in Keycache
- Update all records in Keycache
- Add a force update option
