### PR TITLE
Patch Enforcer to validate against multiple issuers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -170,13 +170,16 @@ attempting to take.
 To assist in the authorization enforcement, the SciTokens library provides
 the `Enforcer` class.
 
-An unique Enforcer object is needed for each thread and issuer:
+An unique Enforcer object is needed for each thread:
 
 ::
 
     >>> enf = scitokens.Enforcer("https://scitokens.org/dteam")
 
-This object will accept tokens targetted to any audience; a more typical
+The ``Enforcer`` class accepts a single issuer string, or a sequence of
+issuer strings, for which tokens are required to match one element.
+
+This object will accept tokens targeted to any audience; a more typical
 use case will look like the following:
 
 ::

--- a/src/scitokens/scitokens.py
+++ b/src/scitokens/scitokens.py
@@ -588,7 +588,10 @@ class Enforcer(object):
         return nbf < self._now
 
     def _validate_iss(self, value):
-        return self._issuer == value
+        if isinstance(self._issuer, str):
+            return value == self._issuer
+        # match a sequence
+        return value in self._issuer
 
     def _validate_iat(self, value):
         return float(value) < self._now


### PR DESCRIPTION
This PR patches the `Enforcer._validate_iss` method to support a sequence of valid `issuer` values.

This allows validating that a token was issued by one in a range of issuers, which is required for the LIGO-Virgo-KAGRA community, which uses separate production and test issuers, and as trialling HTCondor AP token issuers.

Closes #161