### PR TITLE
Fix syntax for intersphinx_mapping in sphinx config

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -245,4 +245,6 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None}
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/", None),
+}


### PR DESCRIPTION
This PR fixes broken sphinx docs builds by addressing outdated `intersphinx_mapping` syntax.