### PR TITLE
Update github actions packaging workflow

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -38,13 +38,13 @@ jobs:
       - name: Create distributions
         run: python -m build . --sdist --wheel --outdir .
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: tarball
           path: scitokens-*.tar.*
           if-no-files-found: error
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: wheel
           path: scitokens*.whl
@@ -105,7 +105,7 @@ jobs:
       - name: Source package info
         run: "rpm -qp *.src.rpm --info"
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: srpm-${{ matrix.dist }}-${{ matrix.version }}
           path: "*.src.rpm"
@@ -195,7 +195,7 @@ jobs:
               rpm -qp "${rpmf}" --requires
           done
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: rpm-${{ matrix.dist }}-${{ matrix.version }}
           path: "*.rpm"

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -60,14 +60,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - dist: centos
-            name: CentOS
-            version: 7
-            container: centos:7
-          - dist: centos
-            name: CentOS
+          - dist: rockylinux
+            name: Rocky Linux
             version: 8
-            container: quay.io/centos/centos:stream8
+            container: rockylinux:8
+          - dist: rockylinux
+            name: Rocky Linux
+            version: 9
+            container: rockylinux:9
           - dist: fedora
             name: Fedora
             version: latest
@@ -82,20 +82,14 @@ jobs:
         with:
           name: tarball
 
-      - name: Configure DNF
-        if: matrix.dist == 'centos' && matrix.version < 8
-        run: ln -s /usr/bin/yum /usr/bin/dnf
-
       - name: Configure EPEL
         if: matrix.dist != 'fedora'
-        run: |
-          dnf -y install epel-release
-          dnf -y install epel-rpm-macros
+        run: dnf -y install epel-release
 
       - name: Configure rpmbuild
         run: |
           dnf -y install \
-              python-srpm-macros \
+              "*-srpm-macros" \
               rpm-build \
           ;
 
@@ -119,14 +113,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - dist: centos
-            name: CentOS
-            version: 7
-            container: centos:7
-          - dist: centos
-            name: CentOS
+          - dist: rockylinux
+            name: Rocky Linux
             version: 8
-            container: quay.io/centos/centos:stream8
+            container: rockylinux:8
+          - dist: rockylinux
+            name: Rocky Linux
+            version: 9
+            container: rockylinux:9
           - dist: fedora
             name: Fedora
             version: latest
@@ -141,30 +135,17 @@ jobs:
         with:
           name: srpm-${{ matrix.dist }}-${{ matrix.version }}
 
-      - name: Configure DNF
-        if: matrix.dist == 'centos' && matrix.version < 8
-        run: ln -s /usr/bin/yum /usr/bin/dnf
+      - name: Configure CRB for EL9
+        if: matrix.version == 9
+        run: |
+          dnf -y install "dnf-command(config-manager)"
+          dnf config-manager --set-enabled crb
 
       - name: Configure EPEL
         if: matrix.dist != 'fedora'
-        run: |
-          dnf -y install epel-release
-          dnf -y install epel-rpm-macros
-
-      - name: Install build tools (yum)
-        if: matrix.dist == 'centos' && matrix.version < 8
-        run: |
-          dnf -y -q install \
-              rpm-build \
-              yum-utils \
-          ;
-
-      - name: Install build dependencies (yum)
-        if: matrix.dist == 'centos' && matrix.version < 8
-        run: yum-builddep -y ${SRPM}
+        run: dnf -y install epel-release
 
       - name: Install build tools (dnf)
-        if: matrix.dist != 'centos' || matrix.version > 7
         run: |
           dnf -y -q install \
               rpm-build \
@@ -172,7 +153,6 @@ jobs:
           ;
 
       - name: Install build dependencies (dnf)
-        if: matrix.dist != 'centos' || matrix.version > 7
         run: dnf builddep -y ${SRPM}
 
       - name: Build binary packages
@@ -209,15 +189,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - dist: centos
-            name: CentOS
-            version: 7
-            container: centos:7
-            yum: true
-          - dist: centos
-            name: CentOS
+          - dist: rockylinux
+            name: Rocky Linux
             version: 8
-            container: quay.io/centos/centos:stream8
+            container: rockylinux:8
+          - dist: rockylinux
+            name: Rocky Linux
+            version: 9
+            container: rockylinux:9
           - dist: fedora
             name: Fedora
             version: latest
@@ -230,15 +209,9 @@ jobs:
         with:
           name: rpm-${{ matrix.dist }}-${{ matrix.version }}
 
-      - name: Configure DNF
-        if: matrix.dist == 'centos' && matrix.version < 8
-        run: ln -s /usr/bin/yum /usr/bin/dnf
-
       - name: Configure EPEL
         if: matrix.dist != 'fedora'
-        run: |
-          dnf -y install epel-release
-          dnf -y install epel-rpm-macros
+        run: dnf -y install epel-release
 
       - name: Install RPMs
         run: dnf -y install *.rpm
@@ -246,14 +219,14 @@ jobs:
   lint-rhel:
     name: Lint RPMs
     runs-on: ubuntu-latest
-    container: quay.io/centos/centos:stream8
+    container: rockylinux:9
     needs:
       - rhel-binary
     steps:
       - name: Download RPM
         uses: actions/download-artifact@v4
         with:
-          name: rpm-centos-8
+          name: rpm-rockylinux-9
 
       - name: Install rpmlint
         run: |

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -78,7 +78,7 @@ jobs:
       TARBALL: "scitokens-*.tar.*"
     steps:
       - name: Download tarball
-        uses: actions/download-artifact@v4.1.9
+        uses: actions/download-artifact@v4
         with:
           name: tarball
 
@@ -137,7 +137,7 @@ jobs:
       SRPM: "python-scitokens-*.src.rpm"
     steps:
       - name: Download SRPM
-        uses: actions/download-artifact@v4.1.9
+        uses: actions/download-artifact@v4
         with:
           name: srpm-${{ matrix.dist }}-${{ matrix.version }}
 
@@ -226,7 +226,7 @@ jobs:
     container: ${{ matrix.container }}
     steps:
       - name: Download RPMs
-        uses: actions/download-artifact@v4.1.9
+        uses: actions/download-artifact@v4
         with:
           name: rpm-${{ matrix.dist }}-${{ matrix.version }}
 
@@ -251,7 +251,7 @@ jobs:
       - rhel-binary
     steps:
       - name: Download RPM
-        uses: actions/download-artifact@v4.1.9
+        uses: actions/download-artifact@v4
         with:
           name: rpm-centos-8
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,6 +13,7 @@ jobs:
   build:
 
     strategy:
+      fail-fast: false
       matrix:
         os: [macOS, Ubuntu, Windows]
         python-version: [3.9, 3.11, 3.12]

--- a/configs/python-scitokens.spec
+++ b/configs/python-scitokens.spec
@@ -7,32 +7,26 @@ Release:        1%{?dist}
 Summary:        SciToken reference implementation library
 
 License:        Apache-2.0
-URL:            https://scitokens.org
-Source0:        %{pypi_source %{pypi_name}}
+Url:            https://scitokens.org
+Source0:        %pypi_source %{pypi_name}
 BuildArch:      noarch
+Prefix:         %{_prefix}
 
 # build requirements
 BuildRequires:  python3-devel
-BuildRequires:  python3-setuptools
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
 
 # test requirements
-%if 0%{?rhel} == 7
-BuildRequires:  python%{python3_pkgversion}-cryptography
-BuildRequires:  python%{python3_pkgversion}-pytest
-BuildRequires:  python%{python3_pkgversion}-jwt >= 1.6.1
-BuildRequires:  python%{python3_pkgversion}-requests
-%else
-BuildRequires:  python3-cryptography
-BuildRequires:  python3-pytest
-BuildRequires:  python3-jwt >= 1.6.1
-BuildRequires:  python3-requests
-%endif
+BuildRequires:  python3dist(cryptography)
+BuildRequires:  python3dist(pyjwt) >= 1.6.1
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(requests)
 
 %description
 SciToken reference implementation library
 
 %package -n     python3-%{pypi_name}
-Obsoletes:      python3-scitokens < 1.6.2-2
 Summary:        %{summary}
 
 %description -n python3-%{pypi_name}
@@ -40,28 +34,20 @@ SciToken reference implementation library
 
 %prep
 %autosetup -n %{pypi_name}-%{version}
-# Remove bundled egg-info
-rm -rf %{pypi_name}.egg-info
 
 %build
-%py3_build
+%py3_build_wheel
 
 %install
-%py3_install
+%py3_install_wheel %{pypi_name}-%{version}-*.whl
 
 %check
-%if 0%{?rhel} == 7
-export PYTHONPATH="%{buildroot}%{python3_sitelib}"
-(cd tests/ && %{__python3} -m pytest --verbose -ra . --no-network)
-%else
 %pytest --verbose -ra tests/ --no-network
-%endif
 
 %files -n python3-%{pypi_name}
-%license LICENSE
-%{python3_sitelib}/%{pypi_name}/
-%{python3_sitelib}/%{pypi_name}-%{version}-py*.egg-info
 %doc README.rst
+%license LICENSE
+%{python3_sitelib}/*
 %{_bindir}/scitokens-admin-create-key
 %{_bindir}/scitokens-admin-create-token
 %{_bindir}/scitokens-verify-token


### PR DESCRIPTION
This PR updates the github actions packaging workflow to not use centos, and now use RHEL7. Builds are now for RL 8 and 9 (and Fedora).