### PR TITLE
Add .packit.yaml for EPEL/Fedora automation and publish.yml for PyPI trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: Publish Python Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  pypi-publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/scitokens
+    permissions:
+      id-token: write  # Required for OIDC trusted publishing
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,46 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+upstream_package_name: scitokens
+downstream_package_name: python-scitokens
+specfile_path: configs/python-scitokens.spec
+
+srpm_build_deps:
+  - git
+
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    targets:
+      - fedora-all
+      - epel-8
+      - epel-9
+      - epel-10
+      - epel-10.1
+
+  - job: propose_downstream
+    trigger: release
+    dist_git_branches:
+      - fedora-all
+      - epel8
+      - epel9
+      - epel10
+      - epel10.1
+
+  - job: koji_build
+    trigger: commit
+    dist_git_branches:
+      - fedora-all
+      - epel8
+      - epel9
+      - epel10
+      - epel10.1
+
+  - job: bodhi_update
+    trigger: koji_build
+    dist_git_branches:
+      - fedora-all
+      - epel8
+      - epel9
+      - epel10
+      - epel10.1


### PR DESCRIPTION
- .packit.yaml: configures Packit for COPR builds (PRs), propose_downstream,
  koji_build, and bodhi_update targeting fedora-all, epel8/9/10/10.1
- .github/workflows/publish.yml: replaces secret-based Twine publishing with
  OIDC trusted publishing via pypa/gh-action-pypi-publish

https://claude.ai/code/session_01NjU1uufdYVYRh32KCZFjmx