### PR TITLE
Raise exception for HTTP error getting demo token

### DIFF
--- a/src/scitokens/utils/demo.py
+++ b/src/scitokens/utils/demo.py
@@ -15,6 +15,7 @@ def token(payload: dict):
     """
     data = json.dumps({'algorithm': "ES256", 'payload': payload})
     resp = requests.post("https://demo.scitokens.org/issue", data=data)
+    resp.raise_for_status()
     return resp.text
 
 

--- a/src/scitokens/utils/demo.py
+++ b/src/scitokens/utils/demo.py
@@ -6,25 +6,27 @@ import json
 import requests
 import scitokens
 
-def token(payload: dict):
+def token(payload: dict, timeout: float = 10):
     """
     Get a signed token for the given payload.
 
     :param dict payload: a dictionary specifying the claims
+    :param float timeout: timeout in seconds for the demo service request
     :returns: an encoded token for the payload
     """
     data = json.dumps({'algorithm': "ES256", 'payload': payload})
-    resp = requests.post("https://demo.scitokens.org/issue", data=data)
+    resp = requests.post("https://demo.scitokens.org/issue", data=data, timeout=timeout)
     resp.raise_for_status()
     return resp.text
 
 
-def parsed_token(payload: dict):
+def parsed_token(payload: dict, timeout: float = 10):
     """
     Get a parsed token for the given payload.
 
     :param dict payload: a dictionary specifying the claims
+    :param float timeout: timeout in seconds for the demo service request
     :returns: a SciToken object
     """
-    token = scitokens.utils.demo.token(payload)
+    token = scitokens.utils.demo.token(payload, timeout=timeout)
     return scitokens.SciToken.deserialize(token)


### PR DESCRIPTION
This PR patches `scitokens.utils.demo.token` to check for HTTP error codes and raise an exception (via the standard requests `Response.raise_for_status()` method).

This avoids the scenario where the 'token' returned by `scitokens.utils.demo.token()` is actually a raw HTML response detailing a 502 error, or similar (see, e.g. [here](https://gitlab.com/gwpy/gwpy/-/jobs/14002197975#L1452)).